### PR TITLE
페이지에 필요한 CSS와 스크립트만 불러오도록 수정

### DIFF
--- a/src/main/webapp/artwork/artworkList.jsp
+++ b/src/main/webapp/artwork/artworkList.jsp
@@ -1,6 +1,9 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
-<%@ include file="/header.jsp"%>
-
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
+<jsp:include page="/header.jsp">
+	<jsp:param name="stylesheet" value="css/artwork.css" />
+	<jsp:param name="script" value="script/artwork.js" />
+</jsp:include>
 <!-- museum.do?command=artworkList 의 목적지 -->
 
 <section class="artwork-list-header">

--- a/src/main/webapp/artwork/artworkUpdateForm.jsp
+++ b/src/main/webapp/artwork/artworkUpdateForm.jsp
@@ -1,5 +1,9 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
-<%@ include file="/header.jsp"%>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
+<jsp:include page="/header.jsp">
+	<jsp:param name="stylesheet" value="css/artwork.css" />
+	<jsp:param name="script" value="script/artwork.js" />
+</jsp:include>
 <h2 class="artwork-write-form-header">예술품 수정</h2>
 <section class="artwork-write-form-main">
 	<form method="post" name="artworkWriteForm" action="museum.do?command=artworkUpdateForm" class="artwork-write-form"

--- a/src/main/webapp/artwork/artworkView.jsp
+++ b/src/main/webapp/artwork/artworkView.jsp
@@ -1,5 +1,9 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
-<%@ include file="/header.jsp"%>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
+<jsp:include page="/header.jsp">
+	<jsp:param name="stylesheet" value="css/artwork.css" />
+	<jsp:param name="script" value="script/artwork.js" />
+</jsp:include>
 
 <section class="artwork-view">
 	<div class="artwork-view-header">

--- a/src/main/webapp/artwork/artworkWriteForm.jsp
+++ b/src/main/webapp/artwork/artworkWriteForm.jsp
@@ -1,5 +1,9 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
-<%@ include file="/header.jsp"%>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
+<jsp:include page="/header.jsp">
+	<jsp:param name="stylesheet" value="css/artwork.css" />
+	<jsp:param name="script" value="script/artwork.js" />
+</jsp:include>
 <h2 class="artwork-write-form-header">예술품 등록</h2>
 <section class="artwork-write-form-main">
 	<form method="post" name="artworkWriteForm" action="museum.do?command=artworkWriteForm" class="artwork-write-form"

--- a/src/main/webapp/gallery/galleryList.jsp
+++ b/src/main/webapp/gallery/galleryList.jsp
@@ -1,6 +1,8 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8"
     pageEncoding="UTF-8"%>
-<%@ include file="/header.jsp"%>
+<jsp:include page="/header.jsp">
+	<jsp:param name="script" value="script/gallery.js" />
+</jsp:include>
 
 <section>
 	<form action="museum.do?command=galleryList" method="post" name="searchForm" class="search-form">

--- a/src/main/webapp/gallery/galleryWriteForm.jsp
+++ b/src/main/webapp/gallery/galleryWriteForm.jsp
@@ -1,8 +1,9 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8"
     pageEncoding="UTF-8"%>
-<%@ include file="/header.jsp"%>
-
-
+<jsp:include page="/header.jsp">
+	<jsp:param name="stylesheet" value="css/galleryForm.css" />
+	<jsp:param name="script" value="script/gallery.js" />
+</jsp:include>
 
 <section>
 	<div class="write_top">

--- a/src/main/webapp/header.jsp
+++ b/src/main/webapp/header.jsp
@@ -17,6 +17,9 @@
 <link rel="stylesheet" href="css/qna_view.css">
 <link rel="stylesheet" href="css/galleryForm.css">
 <link rel="stylesheet" href="css/notice.css">
+<c:forEach items="${paramValues.stylesheet}" var="css">
+	<link rel="stylesheet" href="${css}">
+</c:forEach>
 <script src="script/member.js"></script>
 <script src="script/header.js"></script>
 <script src="script/artwork.js"></script>
@@ -24,6 +27,9 @@
 <script src="script/qna.js"></script>
 <script src="script/gallery.js"></script>
 <script src="script/notice.js"></script>
+<c:forEach items="${paramValues.script}" var="script">
+	<script src="${script}"></script>
+</c:forEach>
 </head>
 <body>
 	<div class="body-wrap">

--- a/src/main/webapp/header.jsp
+++ b/src/main/webapp/header.jsp
@@ -10,23 +10,9 @@
 <link rel="stylesheet" href="css/pagination.css">
 <link rel="stylesheet" href="css/header.css">
 <link rel="stylesheet" href="css/footer.css">
-<link rel="stylesheet" href="css/main.css">
-<link rel="stylesheet" href="css/joinForm.css">
-<link rel="stylesheet" href="css/artwork.css">
-<link rel="stylesheet" href="css/qna_list.css">
-<link rel="stylesheet" href="css/qna_view.css">
-<link rel="stylesheet" href="css/galleryForm.css">
-<link rel="stylesheet" href="css/notice.css">
 <c:forEach items="${paramValues.stylesheet}" var="css">
 	<link rel="stylesheet" href="${css}">
 </c:forEach>
-<script src="script/member.js"></script>
-<script src="script/header.js"></script>
-<script src="script/artwork.js"></script>
-<script src="script/join.js"></script>
-<script src="script/qna.js"></script>
-<script src="script/gallery.js"></script>
-<script src="script/notice.js"></script>
 <c:forEach items="${paramValues.script}" var="script">
 	<script src="${script}"></script>
 </c:forEach>

--- a/src/main/webapp/header.jsp
+++ b/src/main/webapp/header.jsp
@@ -13,8 +13,8 @@
 <c:forEach items="${paramValues.stylesheet}" var="css">
 	<link rel="stylesheet" href="${css}">
 </c:forEach>
-<c:forEach items="${paramValues.script}" var="script">
-	<script src="${script}"></script>
+<c:forEach items="${paramValues.script}" var="js">
+	<script src="${js}"></script>
 </c:forEach>
 </head>
 <body>

--- a/src/main/webapp/member/editMember.jsp
+++ b/src/main/webapp/member/editMember.jsp
@@ -1,5 +1,8 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
-<%@ include file="/header.jsp"%>
+<jsp:include page="/header.jsp">
+	<jsp:param name="stylesheet" value="css/joinForm.css" />
+	<jsp:param name="script" value="script/join.js" />
+</jsp:include>
 <section>
 	<article>
 		<form action="museum.do?command=editMember" method="post" name="joinForm" class="joinForm">

--- a/src/main/webapp/member/joinForm.jsp
+++ b/src/main/webapp/member/joinForm.jsp
@@ -1,5 +1,8 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
-<%@ include file="/header.jsp"%>
+<jsp:include page="/header.jsp">
+	<jsp:param name="stylesheet" value="css/joinForm.css" />
+	<jsp:param name="script" value="script/join.js" />
+</jsp:include>
 <section>
 	<article>
 		<form action="museum.do?command=join" method="post" name="joinForm" class="joinForm">

--- a/src/main/webapp/member/loginForm.jsp
+++ b/src/main/webapp/member/loginForm.jsp
@@ -1,7 +1,9 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt"%>
-<%@ include file="/header.jsp"%>
+<jsp:include page="/header.jsp">
+	<jsp:param name="stylesheet" value="css/login.css" />
+	<jsp:param name="script" value="script/member.js" />
+	<jsp:param name="script" value="script/join.js" />
+</jsp:include>
 
 <section>
 	<article class="login_Form">

--- a/src/main/webapp/notice/insertNoticeForm.jsp
+++ b/src/main/webapp/notice/insertNoticeForm.jsp
@@ -1,7 +1,8 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
-<%@ include file="/header.jsp" %>
+<jsp:include page="/header.jsp">
+	<jsp:param name="stylesheet" value="css/notice.css" />
+	<jsp:param name="script" value="script/notice.js" />
+</jsp:include>
 
 <div class="notice_insert_box">
     <h2>소식지 등록</h2>

--- a/src/main/webapp/notice/noticeCategory.jsp
+++ b/src/main/webapp/notice/noticeCategory.jsp
@@ -1,8 +1,10 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt"%>
-
-<%@ include file="/header.jsp"%>
+<jsp:include page="/header.jsp">
+	<jsp:param name="stylesheet" value="css/notice.css" />
+	<jsp:param name="script" value="script/notice.js" />
+</jsp:include>
 
 <div class="notice_box">
 	<div class="notice_header_box">

--- a/src/main/webapp/notice/noticeDeleteOk.jsp
+++ b/src/main/webapp/notice/noticeDeleteOk.jsp
@@ -1,7 +1,8 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
-<%@ include file="/header.jsp" %>
+<jsp:include page="/header.jsp">
+	<jsp:param name="stylesheet" value="css/notice.css" />
+	<jsp:param name="script" value="script/notice.js" />
+</jsp:include>
 
 
 <script type="text/javascript">

--- a/src/main/webapp/notice/noticeList.jsp
+++ b/src/main/webapp/notice/noticeList.jsp
@@ -1,8 +1,10 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt"%>
-
-<%@ include file="/header.jsp"%>
+<jsp:include page="/header.jsp">
+	<jsp:param name="stylesheet" value="css/notice.css" />
+	<jsp:param name="script" value="script/notice.js" />
+</jsp:include>
 
 <div class="notice_box">
 	<div class="notice_header_box">

--- a/src/main/webapp/notice/noticeView.jsp
+++ b/src/main/webapp/notice/noticeView.jsp
@@ -1,7 +1,9 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt"%>
-<%@ include file="/header.jsp"%>
+<jsp:include page="/header.jsp">
+	<jsp:param name="stylesheet" value="css/notice.css" />
+	<jsp:param name="script" value="script/notice.js" />
+</jsp:include>
 
 
 <div id="noticeView_container">

--- a/src/main/webapp/notice/updateNoticeForm.jsp
+++ b/src/main/webapp/notice/updateNoticeForm.jsp
@@ -1,7 +1,9 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
-<%@ include file="/header.jsp" %>
+<jsp:include page="/header.jsp">
+	<jsp:param name="stylesheet" value="css/notice.css" />
+	<jsp:param name="script" value="script/notice.js" />
+</jsp:include>
 
 <div id="notice_update_box">
 	<h2>소식지 수정</h2>

--- a/src/main/webapp/qna/qnaList.jsp
+++ b/src/main/webapp/qna/qnaList.jsp
@@ -1,7 +1,10 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt"%>
-<%@ include file="/header.jsp"%>
+<jsp:include page="/header.jsp">
+	<jsp:param name="stylesheet" value="css/qna_list.css" />
+	<jsp:param name="script" value="script/qna.js" />
+</jsp:include>
 <section class="qna-list">
 	<h1>Q &amp; A</h1>
 	<div class="qna-list_subheader">

--- a/src/main/webapp/qna/qnaView.jsp
+++ b/src/main/webapp/qna/qnaView.jsp
@@ -1,7 +1,10 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt"%>
-<jsp:include page="/header.jsp" />
+<jsp:include page="/header.jsp">
+	<jsp:param name="stylesheet" value="css/qna_view.css" />
+	<jsp:param name="script" value="script/qna.js" />
+</jsp:include>
 <section class="qna-view">
 	<div class="qna-view_title">
 		<h1>Q &amp; A</h1>

--- a/src/main/webapp/qna/qnaWriteForm.jsp
+++ b/src/main/webapp/qna/qnaWriteForm.jsp
@@ -1,7 +1,8 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt"%>
-<jsp:include page="/header.jsp" />
+<jsp:include page="/header.jsp">
+	<jsp:param name="stylesheet" value="css/qna_view.css" />
+</jsp:include>
 <section class="qna-view">
 	<form action="museum.do?command=qnaWrite" method="post">
 		<h1>


### PR DESCRIPTION
현재 어떤 페이지던 모든 CSS와 JS 파일을 불러옵니다.
이는 CSS 및 JS의 충돌을 일으킬 수 있고, 항상 `heaader.jsp`를 수정하게 만듭니다.

이를 개선하기 위해 `header.jsp`에서 `script`와 `stylesheet` 매개변수를 받도록 수정합니다.
````jsp
<c:forEach items="${paramValues.stylesheet}" var="css">
	<link rel="stylesheet" href="${css}">
</c:forEach>

...

<c:forEach items="${paramValues.script}" var="js">
	<script src="${js}"></script>
</c:forEach>
````

이후 각 페이지의 JSP를 아래와 같이 수정해 해당 페이지에 필요한 파일만 불러오도록 만들 수 있습니다.
````diff
- <%@ include file="/header.jsp" %>
+ <jsp:include page="/header.jsp">
+     <jsp:param name="stylesheet" value="css/a.css" />
+     <jsp:param name="stylesheet" value="css/b.css" />
+     <jsp:param name="script" value="script/a.js" />
+     <jsp:param name="script" value="script/b.js" />
+ </jsp:include>

...
````


## <크롬 브라우저 - 페이지 파일 정보> 전 / 후
![image](https://github.com/himedia-mini-4/museum/assets/13284800/83a748d2-eca1-480f-a3e8-964d1a79b109)

----

## 주의사항

`<%@ include file="" %>` 태그와 달리 `<jsp:include page="">` 태그는 동적으로 처리됩니다.
따라서 `header.jsp`에 포함된 `taglib`을 가져올 수 없습니다.

만약 `header.jsp`의 `taglib`에 의존해 작동하는 JSP 파일의 경우 아래와 같이 `taglib` 구문을 추가해야합니다.
```jsp
<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>

<jsp:include page="/header.jsp">
	<jsp:param name="stylesheet" value="css/artwork.css" />
	<jsp:param name="script" value="script/artwork.js" />
</jsp:include>

...
```