### PR TITLE
feat(Pagination): 반복되는 코드를 줄이기 위한 더 많은 문법 설탕

### DIFF
--- a/src/main/java/com/team4/museum/controller/action/admin/AdminArtworkListAction.java
+++ b/src/main/java/com/team4/museum/controller/action/admin/AdminArtworkListAction.java
@@ -18,13 +18,7 @@ public class AdminArtworkListAction implements Action {
 		String searchWord = request.getParameter("searchWord");
 		String displayState = request.getParameter("displayState");
 
-		Pagination pagination = Pagination
-				.fromRequest(request)
-				.setUrlTemplate("museum.do?command=adminArtworkList&page=%d")
-				.setItemCount(adao.getAllCount());
-
-		request.setAttribute("pagination", pagination);
-
+		Pagination pagination = Pagination.with(request, adao.getAllCount(), "command=adminArtworkList");
 		if (searchWord != null) {
 			request.setAttribute("artworkList", adao.searchArtworkAdmin(pagination, searchWord));
 			request.setAttribute("searchWord", searchWord);

--- a/src/main/java/com/team4/museum/controller/action/admin/AdminMemberListAction.java
+++ b/src/main/java/com/team4/museum/controller/action/admin/AdminMemberListAction.java
@@ -18,11 +18,7 @@ public class AdminMemberListAction implements Action {
 		MemberDao mdao = MemberDao.getInstance();
 		String searchWord = request.getParameter("searchWord");
 
-		Pagination pagination = Pagination
-				.fromRequest(request)
-				.setUrlTemplate("museum.do?command=adminMemberList&page=%d")
-				.setItemCount(mdao.getAllCount());
-
+		Pagination pagination = Pagination.with(request, mdao.getAllCount(), "command=adminMemberList");
 		if (searchWord != null) {
 			request.setAttribute("memberList", mdao.searchMemberList(pagination, searchWord));
 			request.setAttribute("searchWord", searchWord);
@@ -30,7 +26,6 @@ public class AdminMemberListAction implements Action {
 			request.setAttribute("memberList", mdao.getMemberList(pagination));
 		}
 
-		request.setAttribute("pagination", pagination);
 		request.getRequestDispatcher("admin/adminMemberList.jsp").forward(request, response);
 	}
 

--- a/src/main/java/com/team4/museum/controller/action/admin/AdminNoticeListAction.java
+++ b/src/main/java/com/team4/museum/controller/action/admin/AdminNoticeListAction.java
@@ -20,13 +20,8 @@ public class AdminNoticeListAction implements Action {
 		String searchWord = request.getParameter("searchWord");
 		String noticeCategory = request.getParameter("noticeCategory");
 
-		Pagination pagination = Pagination
-				.fromRequest(request)
-				.setUrlTemplate("museum.do?command=adminNoticeList&page=%d")
-				.setItemCount(ndao.getNoticeCount());
-
-		List<NoticeVO> noticeList = null;
-
+		Pagination pagination = Pagination.with(request, ndao.getNoticeCount(), "command=adminNoticeList");
+		List<NoticeVO> noticeList;
 		if (searchWord != null) {
 			noticeList = ndao.searchNoticeList(pagination, searchWord);
 		} else if (noticeCategory != null) {
@@ -37,7 +32,6 @@ public class AdminNoticeListAction implements Action {
 		}
 
 		request.setAttribute("noticeList", noticeList);
-		request.setAttribute("pagination", pagination);
 
 		request.getRequestDispatcher("admin/adminNoticeList.jsp").forward(request, response);
 	}

--- a/src/main/java/com/team4/museum/controller/action/admin/AdminQnaListAction.java
+++ b/src/main/java/com/team4/museum/controller/action/admin/AdminQnaListAction.java
@@ -18,11 +18,7 @@ public class AdminQnaListAction implements Action {
 		String isReply = request.getParameter("isReply");
 		String searchWord = request.getParameter("searchWord");
 
-		Pagination pagination = Pagination
-				.fromRequest(request)
-				.setUrlTemplate("museum.do?command=adminQnaList&page=%d")
-				.setItemCount(qdao.getAllCount());
-
+		Pagination pagination = Pagination.with(request, qdao.getAllCount(), "command=adminQnaList");
 		if (searchWord != null) {
 			request.setAttribute("qnaList", qdao.searchQna(pagination, searchWord));
 
@@ -33,7 +29,6 @@ public class AdminQnaListAction implements Action {
 			request.setAttribute("qnaList", qdao.selectQna(pagination));
 		}
 
-		request.setAttribute("pagination", pagination);
 		request.getRequestDispatcher("admin/adminQnaList.jsp").forward(request, response);
 	}
 

--- a/src/main/java/com/team4/museum/controller/action/notice/NoticeListAction.java
+++ b/src/main/java/com/team4/museum/controller/action/notice/NoticeListAction.java
@@ -28,11 +28,7 @@ public class NoticeListAction implements Action {
 		String category = request.getParameter("category") == null ? NoticeCategory.전체.name()
 				: request.getParameter("category");
 
-		Pagination pagination = Pagination
-				.fromRequest(request)
-				.setUrlTemplate("museum.do?command=noticeList&category=" + category + "&page=%d")
-				.setItemCount(ndao.getNoticeCount(category));
-
+		Pagination pagination = Pagination.with(request, 0, "command=noticeList&category=" + category);
 		List<NoticeVO> noticeList = ndao.selectNoticeList(pagination);
 		if (category.equals(NoticeCategory.전체.name())) {// 전체목록 조회
 			pagination.setItemCount(ndao.getNoticeCount());
@@ -44,14 +40,12 @@ public class NoticeListAction implements Action {
 			request.getRequestDispatcher("notice/noticeNewpaper.jsp").forward(request, response);
 			return;
 		} else { // 카테고리 조회
+			pagination.setItemCount(ndao.getNoticeCount(category));
 			noticeList = ndao.selectCategoryNotice(category, pagination);
 		}
 
-		System.out.println(pagination.getItemCount());
-
 		request.setAttribute("categoryName", category);
 		session.setAttribute("category", category);
-		request.setAttribute("pagination", pagination);
 		request.setAttribute("noticeList", noticeList);
 
 		request.setAttribute("noticeCategory", NoticeCategory.values());

--- a/src/main/java/com/team4/museum/controller/action/qna/QnaListAction.java
+++ b/src/main/java/com/team4/museum/controller/action/qna/QnaListAction.java
@@ -15,12 +15,7 @@ public class QnaListAction implements Action {
 	public void execute(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
 		QnaDao qdao = QnaDao.getInstance();
 
-		Pagination pagination = Pagination
-				.fromRequest(request)
-				.setUrlTemplate("museum.do?command=qnaList&page=%d")
-				.setItemCount(qdao.getAllCount());
-
-		request.setAttribute("pagination", pagination);
+		Pagination pagination = Pagination.with(request, qdao.getAllCount(), "command=qnaList");
 		request.setAttribute("qnaList", qdao.selectQna(pagination));
 
 		request.getRequestDispatcher("qna/qnaList.jsp").forward(request, response);

--- a/src/main/java/com/team4/museum/dao/ArtworkDao.java
+++ b/src/main/java/com/team4/museum/dao/ArtworkDao.java
@@ -68,8 +68,7 @@ public class ArtworkDao {
 				pstmt -> {
 					pstmt.setString(1, searchWord);
 					pstmt.setString(2, searchWord);
-					pstmt.setInt(3, pagination.getLimit());
-					pstmt.setInt(4, pagination.getOffset());
+					pagination.applyTo(pstmt, 3, 4);
 				},
 				ArtworkDao::extractArtworkVO);
 	}
@@ -123,8 +122,7 @@ public class ArtworkDao {
 				"SELECT * FROM artwork WHERE displayyn=? ORDER BY aseq DESC LIMIT ? OFFSET ?",
 				pstmt -> {
 					pstmt.setString(1, displayState);
-					pstmt.setInt(2, pagination.getLimit());
-					pstmt.setInt(3, pagination.getOffset());
+					pagination.applyTo(pstmt, 2, 3);
 				},
 				ArtworkDao::extractArtworkVO);
 	}
@@ -160,10 +158,7 @@ public class ArtworkDao {
 	public List<ArtworkVO> selectArtwork(Pagination pagination) {
 		return executeSelect(
 				"SELECT * FROM artwork ORDER BY aseq DESC LIMIT ? OFFSET ?",
-				pstmt -> {
-					pstmt.setInt(1, pagination.getLimit());
-					pstmt.setInt(2, pagination.getOffset());
-				},
+				pagination::applyTo,
 				ArtworkDao::extractArtworkVO);
 	}
 

--- a/src/main/java/com/team4/museum/dao/FavoriteDao.java
+++ b/src/main/java/com/team4/museum/dao/FavoriteDao.java
@@ -28,8 +28,7 @@ public class FavoriteDao {
 				"SELECT * FROM favorite_view WHERE member_id = ? ORDER BY aseq DESC LIMIT ? OFFSET ?",
 				pstmt -> {
 					pstmt.setString(1, memberId);
-					pstmt.setInt(2, pagination.getLimit());
-					pstmt.setInt(3, pagination.getOffset());
+					pagination.applyTo(pstmt, 2, 3);
 				},
 				FavoriteDao::extractFavoriteVO);
 	}

--- a/src/main/java/com/team4/museum/dao/MemberDao.java
+++ b/src/main/java/com/team4/museum/dao/MemberDao.java
@@ -32,10 +32,7 @@ public class MemberDao {
 	public List<MemberVO> getMemberList(Pagination pagination) {
 		return executeSelect(
 				"SELECT * FROM member ORDER BY id DESC LIMIT ? OFFSET ?",
-				pstmt -> {
-					pstmt.setInt(1, pagination.getLimit());
-					pstmt.setInt(2, pagination.getOffset());
-				},
+				pagination::applyTo,
 				MemberDao::extractMemberVO);
 	}
 
@@ -48,8 +45,7 @@ public class MemberDao {
 					pstmt.setString(1, searchWord);
 					pstmt.setString(2, searchWord);
 					pstmt.setString(3, searchWord);
-					pstmt.setInt(4, pagination.getLimit());
-					pstmt.setInt(5, pagination.getOffset());
+					pagination.applyTo(pstmt, 4, 5);
 				},
 				MemberDao::extractMemberVO);
 	}

--- a/src/main/java/com/team4/museum/dao/MemberGalleryDao.java
+++ b/src/main/java/com/team4/museum/dao/MemberGalleryDao.java
@@ -74,10 +74,7 @@ public class MemberGalleryDao {
 	public List<MemberGalleryVO> getAllGallery(Pagination pagination) {
 		return executeSelect(
 				"SELECT * FROM member_gallery ORDER BY mseq DESC LIMIT ? OFFSET ?",
-				pstmt -> {
-					pstmt.setInt(1, pagination.getLimit());
-					pstmt.setInt(2, pagination.getOffset());
-				},
+				pagination::applyTo,
 				MemberGalleryDao::extractMemberGalleryVO);
 	}
 

--- a/src/main/java/com/team4/museum/dao/NoticeDao.java
+++ b/src/main/java/com/team4/museum/dao/NoticeDao.java
@@ -29,13 +29,10 @@ final public class NoticeDao {
 	PreparedStatement pstmt = null;
 	ResultSet rs = null;
 
-	public List<NoticeVO> selectNoticeList(Pagination paging) {
+	public List<NoticeVO> selectNoticeList(Pagination pagination) {
 		return executeSelect(
 				"SELECT * FROM notice LIMIT ? OFFSET ? ",
-				pstmt -> {
-					pstmt.setInt(1, paging.getLimit());
-					pstmt.setInt(2, paging.getOffset());
-				},
+				pagination::applyTo,
 				NoticeDao::extractNoticeVO);
 	}
 
@@ -46,13 +43,12 @@ final public class NoticeDao {
 	 * NoticeDAO::extractNoticeVO); }
 	 */
 
-	public List<NoticeVO> selectCategoryNotice(String category, Pagination paging) {
+	public List<NoticeVO> selectCategoryNotice(String category, Pagination pagination) {
 		return executeSelect(
 				"SELECT * FROM notice WHERE category = ? ORDER BY nseq DESC LIMIT ? OFFSET ?",
 				pstmt -> {
 					pstmt.setString(1, category);
-					pstmt.setInt(2, paging.getLimit());
-					pstmt.setInt(3, paging.getOffset());
+					pagination.applyTo(pstmt, 2, 3);
 				},
 				NoticeDao::extractNoticeVO);
 	}
@@ -155,8 +151,7 @@ final public class NoticeDao {
 				pstmt -> {
 					pstmt.setString(1, searchWord);
 					pstmt.setString(2, searchWord);
-					pstmt.setInt(3, pagination.getLimit());
-					pstmt.setInt(4, pagination.getOffset());
+					pagination.applyTo(pstmt, 3, 4);
 				},
 				NoticeDao::extractNoticeVO);
 	}

--- a/src/main/java/com/team4/museum/dao/QnaDao.java
+++ b/src/main/java/com/team4/museum/dao/QnaDao.java
@@ -31,10 +31,7 @@ public class QnaDao {
 	public List<QnaVO> selectQna(Pagination pagination) {
 		return executeSelect(
 				"SELECT * FROM qna ORDER BY qseq DESC LIMIT ? OFFSET ?",
-				pstmt -> {
-					pstmt.setInt(1, pagination.getLimit());
-					pstmt.setInt(2, pagination.getOffset());
-				},
+				pagination::applyTo,
 				QnaDao::extractQnaVO);
 	}
 
@@ -45,13 +42,7 @@ public class QnaDao {
 		} else {
 			query = "SELECT * FROM qna WHERE reply IS NULL ORDER BY qseq DESC LIMIT ? OFFSET ?";
 		}
-		return executeSelect(
-				query,
-				pstmt -> {
-					pstmt.setInt(1, pagination.getLimit());
-					pstmt.setInt(2, pagination.getOffset());
-				},
-				QnaDao::extractQnaVO);
+		return executeSelect(query, pagination::applyTo, QnaDao::extractQnaVO);
 	}
 
 	public QnaVO getQna(int qseq) {
@@ -123,8 +114,7 @@ public class QnaDao {
 				pstmt -> {
 					pstmt.setString(1, searchWord);
 					pstmt.setString(2, searchWord);
-					pstmt.setInt(3, pagination.getLimit());
-					pstmt.setInt(4, pagination.getOffset());
+					pagination.applyTo(pstmt, 3, 4);
 				},
 				QnaDao::extractQnaVO);
 	}

--- a/src/main/java/com/team4/museum/util/Pagination.java
+++ b/src/main/java/com/team4/museum/util/Pagination.java
@@ -255,6 +255,28 @@ public class Pagination {
 	}
 
 	/**
+	 * Pagination 객체를 요청의 `pagination` 속성으로 설정합니다.
+	 * 
+	 * @param request 요청
+	 * @return Pagination 객체
+	 */
+	public Pagination applyTo(HttpServletRequest request) {
+		return applyTo(request, "pagination");
+	}
+
+	/**
+	 * Pagination 객체를 요청의 속성으로 설정합니다.
+	 * 
+	 * @param request       요청
+	 * @param attributeName 속성 이름
+	 * @return Pagination 객체
+	 */
+	public Pagination applyTo(HttpServletRequest request, String attributeName) {
+		request.setAttribute(attributeName, this);
+		return this;
+	}
+
+	/**
 	 * 페이지네이션 정보를 요청에서 가져와서 Pagination 객체를 생성합니다.
 	 * 
 	 * @param request 요청

--- a/src/main/java/com/team4/museum/util/Pagination.java
+++ b/src/main/java/com/team4/museum/util/Pagination.java
@@ -1,5 +1,8 @@
 package com.team4.museum.util;
 
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
 import jakarta.servlet.http.HttpServletRequest;
 
 public class Pagination {
@@ -274,6 +277,29 @@ public class Pagination {
 	public Pagination applyTo(HttpServletRequest request, String attributeName) {
 		request.setAttribute(attributeName, this);
 		return this;
+	}
+
+	/**
+	 * SQL 쿼리 문의 1, 2번 파라미터에 LIMIT과 OFFSET을 설정합니다.
+	 * 
+	 * @param pstmt SQL 쿼리 문 객체
+	 * @throws SQLException
+	 */
+	public void applyTo(PreparedStatement pstmt) throws SQLException {
+		applyTo(pstmt, 1, 2);
+	}
+
+	/**
+	 * SQL 쿼리 문의 파라미터에 LIMIT과 OFFSET을 설정합니다.
+	 * 
+	 * @param pstmt       SQL 쿼리 문 객체
+	 * @param limitIndex  LIMIT 파라미터 인덱스
+	 * @param offsetIndex OFFSET 파라미터 인덱스
+	 * @throws SQLException
+	 */
+	public void applyTo(PreparedStatement pstmt, int limitIndex, int offsetIndex) throws SQLException {
+		pstmt.setInt(limitIndex, getLimit());
+		pstmt.setInt(offsetIndex, getOffset());
 	}
 
 	/**

--- a/src/main/java/com/team4/museum/util/Pagination.java
+++ b/src/main/java/com/team4/museum/util/Pagination.java
@@ -277,7 +277,7 @@ public class Pagination {
 	}
 
 	/**
-	 * 페이지네이션 정보를 요청에서 가져와서 Pagination 객체를 생성합니다.
+	 * 요청의 `page` 파라미터로 부터 Pagination 객체를 생성합니다.
 	 * 
 	 * @param request 요청
 	 * @return Pagination 객체
@@ -291,6 +291,21 @@ public class Pagination {
 		}
 
 		return new Pagination().setCurrentPage(page);
+	}
+
+	/**
+	 * 요청의 `page` 파라미터로 부터 Pagination 객체를 생성하고 아이템의 총 갯수와 URL 템플릿을 설정합니다.
+	 * 
+	 * @param request     요청
+	 * @param itemCount   아이템의 총 갯수
+	 * @param urlTemplate URL 템플릿
+	 * @return Pagination 객체
+	 */
+	public static Pagination with(HttpServletRequest request, int itemCount, String urlParams) {
+		return fromRequest(request)
+				.setItemCount(itemCount)
+				.setUrlTemplate("museum.do?" + urlParams + "&page=%d")
+				.applyTo(request);
 	}
 
 }


### PR DESCRIPTION
### 311e29a39d9637833fc884c88c00737db660889b Pagination 객체를 request의 속성으로 설정하는 `applyTo(HttpServletRequest)` 메서드 추가
`request.setAttribute("pagination", pagination)`을 수행하는 메서드를 추가했습니다.

````diff
- Pagination pagination = Pagination.fromRequest(request);
- request.setAttribute("pagination", pagination);

+ Pagination pagination = Pagination.fromRequest(request).applyTo(request);
````

-----

### aca21050401ed23802f35cdf7977ae01c44e2cbf Pagination 객체를 생성하고 request의 속성으로 설정하는 `with(HttpServletRequest)`  메서드 추가
반복적인 아이템의 총 갯수와 URL 템플릿 설정을 포함한 팩토리 메서드를 추가했습니다.


````diff
- Pagination pagination = Pagination
-     .fromRequest(request)
-     .setUrlTemplate("museum.do?command=adminArtworkList&page=%d")
-     .setItemCount(adao.getAllCount());
- request.setAttribute("pagination", pagination);

+ Pagination pagination = Pagination.with(request, adao.getAllCount(), "command=adminArtworkList");
````

-----

### 8808060dd7910dd84b32fb5102e4cd19c2664d6a SQL 쿼리 문의 파라미터에 LIMIT과 OFFSET을 설정하는 `applyTo(PreparedStatement)` 메서드 추가
반복적인 SQL 파라미터 설정을 수행하는 메서드를 추가했습니다.

````diff
- pstmt -> {
-     pstmt.setInt(1, pagination.getLimit());
-     pstmt.setInt(2, pagination.getOffset());
- },
+ pagination::applyTo
````

1과 2가 아닌 위치의 파라미터를 설정하는 `applyTo(PreparedStatement, int, int)` 메서드도 추가했습니다.

````diff
pstmt -> {
    pstmt.setString(1, "something");
-   pstmt.setInt(2, pagination.getLimit());
-   pstmt.setInt(3, pagination.getOffset());
+   pagination.applyTo(pstmt, 2, 3);
},
````