### PR TITLE
feat: Ajax 사용 방식 개선

### DIFF
--- a/src/main/java/com/team4/museum/controller/ActionFactory.java
+++ b/src/main/java/com/team4/museum/controller/ActionFactory.java
@@ -23,15 +23,15 @@ import com.team4.museum.controller.action.gallery.GalleryListAction;
 import com.team4.museum.controller.action.gallery.GalleryWriteAction;
 import com.team4.museum.controller.action.gallery.GalleryWriteFormAction;
 import com.team4.museum.controller.action.member.IdcheckFormAction;
-import com.team4.museum.controller.action.member.JoinAction;
+import com.team4.museum.controller.action.member.JoinAjaxAction;
 import com.team4.museum.controller.action.member.JoinFormAction;
-import com.team4.museum.controller.action.member.LoginAction;
+import com.team4.museum.controller.action.member.LoginAjaxAction;
 import com.team4.museum.controller.action.member.LoginFormAction;
-import com.team4.museum.controller.action.member.LogoutAction;
+import com.team4.museum.controller.action.member.LogoutAjaxAction;
 import com.team4.museum.controller.action.member.MyPageAction;
 import com.team4.museum.controller.action.member.MyPageEditAction;
 import com.team4.museum.controller.action.member.MyPageEditFormAction;
-import com.team4.museum.controller.action.member.MyPageFavoriteAction;
+import com.team4.museum.controller.action.member.MyPageFavoriteAjaxAction;
 import com.team4.museum.controller.action.notice.DeleteNoticeAction;
 import com.team4.museum.controller.action.notice.InsertNoticeAction;
 import com.team4.museum.controller.action.notice.InsertNoticeFormAction;
@@ -41,7 +41,7 @@ import com.team4.museum.controller.action.notice.NoticeViewWithoutCntAction;
 import com.team4.museum.controller.action.notice.UpdateNoticeAction;
 import com.team4.museum.controller.action.notice.UpdateNoticeFormAction;
 import com.team4.museum.controller.action.qna.QnaListAction;
-import com.team4.museum.controller.action.qna.QnaPwdCheckAction;
+import com.team4.museum.controller.action.qna.QnaPwdCheckAjaxAction;
 import com.team4.museum.controller.action.qna.QnaReplyAction;
 import com.team4.museum.controller.action.qna.QnaViewAction;
 import com.team4.museum.controller.action.qna.QnaWriteAction;
@@ -66,15 +66,15 @@ public class ActionFactory {
 
 		// member actions
 		case "loginForm" -> new LoginFormAction();
-		case "login" -> new LoginAction();
-		case "logout" -> new LogoutAction();
-		case "join" -> new JoinAction();
+		case "login" -> new LoginAjaxAction();
+		case "logout" -> new LogoutAjaxAction();
+		case "join" -> new JoinAjaxAction();
 		case "joinForm" -> new JoinFormAction();
 		case "idcheckForm" -> new IdcheckFormAction();
 		case "mypage" -> new MyPageAction();
 		case "mypageEditMemberForm" -> new MyPageEditFormAction();
 		case "mypageEditMember" -> new MyPageEditAction();
-		case "mypageFavorite" -> new MyPageFavoriteAction();
+		case "mypageFavorite" -> new MyPageFavoriteAjaxAction();
 
 		// artwork actions
 		case "artworkList" -> new ArtworkListAction();
@@ -88,7 +88,7 @@ public class ActionFactory {
 
 		// QnA actions
 		case "qnaList" -> new QnaListAction();
-		case "qnaPwdCheck" -> new QnaPwdCheckAction();
+		case "qnaPwdCheck" -> new QnaPwdCheckAjaxAction();
 		case "qnaView" -> new QnaViewAction();
 		case "qnaReply" -> new QnaReplyAction();
 		case "qnaWriteForm" -> new QnaWriteFormAction();

--- a/src/main/java/com/team4/museum/controller/action/AjaxAction.java
+++ b/src/main/java/com/team4/museum/controller/action/AjaxAction.java
@@ -1,5 +1,14 @@
 package com.team4.museum.controller.action;
 
+import static jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static jakarta.servlet.http.HttpServletResponse.SC_FORBIDDEN;
+import static jakarta.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
+import static jakarta.servlet.http.HttpServletResponse.SC_NOT_FOUND;
+import static jakarta.servlet.http.HttpServletResponse.SC_NOT_IMPLEMENTED;
+import static jakarta.servlet.http.HttpServletResponse.SC_NO_CONTENT;
+import static jakarta.servlet.http.HttpServletResponse.SC_OK;
+import static jakarta.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
+
 import java.io.IOException;
 
 import com.team4.museum.util.AjaxResult;
@@ -26,4 +35,103 @@ abstract public class AjaxAction implements Action {
 	abstract protected AjaxResult handleAjaxRequest(HttpServletRequest request, HttpServletResponse response)
 			throws ServletException, IOException;
 
+	protected static AjaxResult ok() {
+		return ok("성공");
+	}
+
+	protected static AjaxResult ok(String message) {
+		return ok(message, "");
+	}
+
+	protected static AjaxResult ok(String message, String url) {
+		return new AjaxResult(SC_OK, message, url);
+	}
+
+	protected static AjaxResult internalServerError() {
+		return internalServerError("서버 오류가 발생했습니다");
+	}
+
+	protected static AjaxResult internalServerError(String message) {
+		return internalServerError(message, "");
+	}
+
+	protected static AjaxResult internalServerError(String message, String url) {
+		return new AjaxResult(SC_INTERNAL_SERVER_ERROR, message, url);
+	}
+
+	protected static AjaxResult badRequest() {
+		return badRequest("잘못된 요청입니다");
+	}
+
+	protected static AjaxResult badRequest(String message) {
+		return badRequest(message, "");
+	}
+
+	protected static AjaxResult badRequest(String message, String url) {
+		return new AjaxResult(SC_BAD_REQUEST, message, url);
+	}
+
+	protected static AjaxResult unauthorized() {
+		return unauthorized("로그인이 필요합니다");
+	}
+
+	protected static AjaxResult unauthorized(String message) {
+		return unauthorized(message, "");
+	}
+
+	protected static AjaxResult unauthorized(String message, String url) {
+		return new AjaxResult(SC_UNAUTHORIZED, message, url);
+	}
+
+	protected static AjaxResult forbidden() {
+		return forbidden("접근 권한이 없습니다");
+	}
+
+	protected static AjaxResult forbidden(String message) {
+		return forbidden(message, "");
+	}
+
+	protected static AjaxResult forbidden(String message, String url) {
+		return new AjaxResult(SC_FORBIDDEN, message, url);
+	}
+
+	protected static AjaxResult noContent() {
+		return noContent("내용이 없습니다");
+	}
+
+	protected static AjaxResult noContent(String message) {
+		return noContent(message, "");
+	}
+
+	protected static AjaxResult noContent(String message, String url) {
+		return new AjaxResult(SC_NO_CONTENT, message, url);
+	}
+
+	protected static AjaxResult notFound() {
+		return notFound("찾을 수 없습니다");
+	}
+
+	protected static AjaxResult notFound(String message) {
+		return notFound(message, "");
+	}
+
+	protected static AjaxResult notFound(String message, String url) {
+		return new AjaxResult(SC_NOT_FOUND, message, url);
+	}
+
+	protected static AjaxResult notImplemented() {
+		return notImplemented("구현되지 않은 요청입니다");
+	}
+
+	protected static AjaxResult notImplemented(String message) {
+		return notImplemented(message, "");
+	}
+
+	protected static AjaxResult notImplemented(String message, String url) {
+		return new AjaxResult(SC_NOT_IMPLEMENTED, message, url);
+	}
+
+	protected static AjaxResult requireParameter(String parameter) {
+		return badRequest("'" + parameter + "'를 입력해주세요");
+	}
 }

--- a/src/main/java/com/team4/museum/controller/action/AjaxAction.java
+++ b/src/main/java/com/team4/museum/controller/action/AjaxAction.java
@@ -1,0 +1,29 @@
+package com.team4.museum.controller.action;
+
+import java.io.IOException;
+
+import com.team4.museum.util.AjaxResult;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+abstract public class AjaxAction implements Action {
+
+	@Override
+	public void execute(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+		AjaxResult result = handleAjaxRequest(request, response);
+
+		response.setStatus(result.code);
+		response.setContentType("application/json");
+		try {
+			response.getWriter().write(result.toJson());
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+	}
+
+	abstract protected AjaxResult handleAjaxRequest(HttpServletRequest request, HttpServletResponse response)
+			throws ServletException, IOException;
+
+}

--- a/src/main/java/com/team4/museum/controller/action/AjaxAction.java
+++ b/src/main/java/com/team4/museum/controller/action/AjaxAction.java
@@ -1,6 +1,7 @@
 package com.team4.museum.controller.action;
 
 import static jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static jakarta.servlet.http.HttpServletResponse.SC_CREATED;
 import static jakarta.servlet.http.HttpServletResponse.SC_FORBIDDEN;
 import static jakarta.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
 import static jakarta.servlet.http.HttpServletResponse.SC_NOT_FOUND;
@@ -45,6 +46,18 @@ abstract public class AjaxAction implements Action {
 
 	protected static AjaxResult ok(String message, String url) {
 		return new AjaxResult(SC_OK, message, url);
+	}
+
+	protected static AjaxResult created() {
+		return created("생성되었습니다");
+	}
+
+	protected static AjaxResult created(String message) {
+		return created(message, "");
+	}
+
+	protected static AjaxResult created(String message, String url) {
+		return new AjaxResult(SC_CREATED, message, url);
 	}
 
 	protected static AjaxResult internalServerError() {

--- a/src/main/java/com/team4/museum/controller/action/gallery/GalleryWriteAction.java
+++ b/src/main/java/com/team4/museum/controller/action/gallery/GalleryWriteAction.java
@@ -1,9 +1,10 @@
 package com.team4.museum.controller.action.gallery;
 
+import static com.team4.museum.controller.action.member.LoginAjaxAction.isLogined;
+
 import java.io.IOException;
 
 import com.team4.museum.controller.action.Action;
-import com.team4.museum.controller.action.member.LoginAction;
 
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -13,7 +14,7 @@ public class GalleryWriteAction implements Action {
 
 	@Override
 	public void execute(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-		if (LoginAction.isLogined(request, response)) {
+		if (isLogined(request, response)) {
 			request.getRequestDispatcher("gallery/galleryWriteForm.jsp").forward(request, response);
 		}
 	}

--- a/src/main/java/com/team4/museum/controller/action/member/JoinAction.java
+++ b/src/main/java/com/team4/museum/controller/action/member/JoinAction.java
@@ -4,26 +4,18 @@ import static com.team4.museum.util.AjaxResult.BAD_REQUEST;
 import static com.team4.museum.util.AjaxResult.INTERNAL_SERVER_ERROR;
 import static com.team4.museum.util.AjaxResult.OK;
 
-import java.io.IOException;
-
-import com.team4.museum.controller.action.Action;
+import com.team4.museum.controller.action.AjaxAction;
 import com.team4.museum.dao.MemberDao;
 import com.team4.museum.util.AjaxResult;
 import com.team4.museum.util.UrlUtil;
 import com.team4.museum.vo.MemberVO;
 
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-public class JoinAction implements Action {
+public class JoinAction extends AjaxAction {
 
-	@Override
-	public void execute(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-		getResult(request, response).applyToResponse(response);
-	}
-
-	private AjaxResult getResult(HttpServletRequest request, HttpServletResponse response) {
+	protected AjaxResult handleAjaxRequest(HttpServletRequest request, HttpServletResponse response) {
 		MemberVO mvo = new MemberVO();
 
 		// 파라미터에 'name'가 없으면 BAD_REQUEST 를 반환

--- a/src/main/java/com/team4/museum/controller/action/member/JoinAjaxAction.java
+++ b/src/main/java/com/team4/museum/controller/action/member/JoinAjaxAction.java
@@ -13,7 +13,7 @@ import com.team4.museum.vo.MemberVO;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-public class JoinAction extends AjaxAction {
+public class JoinAjaxAction extends AjaxAction {
 
 	protected AjaxResult handleAjaxRequest(HttpServletRequest request, HttpServletResponse response) {
 		MemberVO mvo = new MemberVO();

--- a/src/main/java/com/team4/museum/controller/action/member/JoinAjaxAction.java
+++ b/src/main/java/com/team4/museum/controller/action/member/JoinAjaxAction.java
@@ -17,41 +17,41 @@ public class JoinAjaxAction extends AjaxAction {
 		// 'name' 파라미터가 없는 경우
 		String name = request.getParameter("name");
 		if (name == null || name.equals("")) {
-			return AjaxResult.requireParameter("name");
+			return requireParameter("name");
 		}
 		mvo.setName(name);
 
 		// 'id' 파라미터가 없는 경우
 		String id = request.getParameter("id");
 		if (id == null || id.equals("")) {
-			return AjaxResult.requireParameter("id");
+			return requireParameter("id");
 		}
 		mvo.setId(id);
 
 		// 'pwd' 파라미터가 없는 경우
 		String pwd = request.getParameter("pwd");
 		if (pwd == null || pwd.equals("")) {
-			return AjaxResult.requireParameter("pwd");
+			return requireParameter("pwd");
 		}
 		mvo.setPwd(pwd);
 
 		// 'email' 파라미터가 없는 경우
 		String email = request.getParameter("email");
 		if (email == null || email.equals("")) {
-			return AjaxResult.requireParameter("email");
+			return requireParameter("email");
 		}
 		mvo.setEmail(email);
 
 		// 'phone' 파라미터가 없는 경우
 		String phone = request.getParameter("phone");
 		if (phone == null || phone.equals("")) {
-			return AjaxResult.requireParameter("phone");
+			return requireParameter("phone");
 		}
 		mvo.setPhone(phone);
 
 		// 회원가입에 실패한 경우
 		if (MemberDao.getInstance().insertMember(mvo) == 0) {
-			return AjaxResult.fail("회원가입에 실패하였습니다");
+			return internalServerError("회원가입에 실패하였습니다");
 		}
 
 		// 돌아갈 페이지 정보를 확인하고, 없으면 index 페이지로 이동
@@ -62,7 +62,7 @@ public class JoinAjaxAction extends AjaxAction {
 		}
 
 		// 돌아갈 페이지 정보와 함께 성공 메시지를 반환
-		return AjaxResult.success("회원가입이 완료되었습니다", returnUrl);
+		return ok("회원가입이 완료되었습니다", returnUrl);
 	}
 
 }

--- a/src/main/java/com/team4/museum/controller/action/member/JoinAjaxAction.java
+++ b/src/main/java/com/team4/museum/controller/action/member/JoinAjaxAction.java
@@ -1,8 +1,8 @@
 package com.team4.museum.controller.action.member;
 
-import static com.team4.museum.util.AjaxResult.BAD_REQUEST;
-import static com.team4.museum.util.AjaxResult.INTERNAL_SERVER_ERROR;
-import static com.team4.museum.util.AjaxResult.OK;
+import static jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static jakarta.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
+import static jakarta.servlet.http.HttpServletResponse.SC_OK;
 
 import com.team4.museum.controller.action.AjaxAction;
 import com.team4.museum.dao.MemberDao;
@@ -18,43 +18,44 @@ public class JoinAjaxAction extends AjaxAction {
 	protected AjaxResult handleAjaxRequest(HttpServletRequest request, HttpServletResponse response) {
 		MemberVO mvo = new MemberVO();
 
-		// 파라미터에 'name'가 없으면 BAD_REQUEST 를 반환
+		// 파라미터에 'name'가 없으면 SC_BAD_REQUEST 를 반환
 		String name = request.getParameter("name");
 		if (name == null || name.equals("")) {
-			return new AjaxResult(BAD_REQUEST, "'name'를 입력해주세요");
+			return new AjaxResult(SC_BAD_REQUEST, "'name'를 입력해주세요");
 		}
 		mvo.setName(name);
 
+		// 파라미터에 'id'가 없으면 SC_BAD_REQUEST 를 반환
 		String id = request.getParameter("id");
 		if (id == null || id.equals("")) {
-			return new AjaxResult(BAD_REQUEST, "'id'를 입력해주세요");
+			return new AjaxResult(SC_BAD_REQUEST, "'id'를 입력해주세요");
 		}
 		mvo.setId(id);
 
-		// 파라미터에 'pwd'가 없으면 BAD_REQUEST 를 반환
+		// 파라미터에 'pwd'가 없으면 SC_BAD_REQUEST 를 반환
 		String pwd = request.getParameter("pwd");
 		if (pwd == null || pwd.equals("")) {
-			return new AjaxResult(BAD_REQUEST, "'pwd'를 입력해주세요");
+			return new AjaxResult(SC_BAD_REQUEST, "'pwd'를 입력해주세요");
 		}
 		mvo.setPwd(pwd);
 
-		// 파라미터에 'email'가 없으면 BAD_REQUEST 를 반환
+		// 파라미터에 'email'가 없으면 SC_BAD_REQUEST 를 반환
 		String email = request.getParameter("email");
 		if (email == null || email.equals("")) {
-			return new AjaxResult(BAD_REQUEST, "'email'를 입력해주세요");
+			return new AjaxResult(SC_BAD_REQUEST, "'email'를 입력해주세요");
 		}
 		mvo.setEmail(email);
 
-		// 파라미터에 'pwd'가 없으면 BAD_REQUEST 를 반환
+		// 파라미터에 'pwd'가 없으면 SC_BAD_REQUEST 를 반환
 		String phone = request.getParameter("phone");
 		if (phone == null || phone.equals("")) {
-			return new AjaxResult(BAD_REQUEST, "'phone'를 입력해주세요");
+			return new AjaxResult(SC_BAD_REQUEST, "'phone'를 입력해주세요");
 		}
 		mvo.setPhone(phone);
 
-		// 회원가입 실패 시 INTERNAL_SERVER_ERROR 를 반환
+		// 회원가입 실패 시 SC_INTERNAL_SERVER_ERROR 를 반환
 		if (MemberDao.getInstance().insertMember(mvo) == 0) {
-			return new AjaxResult(INTERNAL_SERVER_ERROR, "회원가입 실패\n관리자에게 문의하세요");
+			return new AjaxResult(SC_INTERNAL_SERVER_ERROR, "회원가입 실패\n관리자에게 문의하세요");
 		}
 
 		// 돌아갈 페이지 정보를 확인하고, 없으면 index 페이지로 이동
@@ -64,8 +65,8 @@ public class JoinAjaxAction extends AjaxAction {
 			returnUrl = UrlUtil.decode(returnUrlParam);
 		}
 
-		// 돌아갈 페이지 정보와 함께 OK 를 반환
-		return new AjaxResult(OK, "회원가입에 성공하였습니다", returnUrl);
+		// 돌아갈 페이지 정보와 함께 SC_OK 를 반환
+		return new AjaxResult(SC_OK, "회원가입에 성공하였습니다", returnUrl);
 	}
 
 }

--- a/src/main/java/com/team4/museum/controller/action/member/JoinAjaxAction.java
+++ b/src/main/java/com/team4/museum/controller/action/member/JoinAjaxAction.java
@@ -1,9 +1,5 @@
 package com.team4.museum.controller.action.member;
 
-import static jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
-import static jakarta.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
-import static jakarta.servlet.http.HttpServletResponse.SC_OK;
-
 import com.team4.museum.controller.action.AjaxAction;
 import com.team4.museum.dao.MemberDao;
 import com.team4.museum.util.AjaxResult;
@@ -18,44 +14,44 @@ public class JoinAjaxAction extends AjaxAction {
 	protected AjaxResult handleAjaxRequest(HttpServletRequest request, HttpServletResponse response) {
 		MemberVO mvo = new MemberVO();
 
-		// 파라미터에 'name'가 없으면 SC_BAD_REQUEST 를 반환
+		// 'name' 파라미터가 없는 경우
 		String name = request.getParameter("name");
 		if (name == null || name.equals("")) {
-			return new AjaxResult(SC_BAD_REQUEST, "'name'를 입력해주세요");
+			return AjaxResult.requireParameter("name");
 		}
 		mvo.setName(name);
 
-		// 파라미터에 'id'가 없으면 SC_BAD_REQUEST 를 반환
+		// 'id' 파라미터가 없는 경우
 		String id = request.getParameter("id");
 		if (id == null || id.equals("")) {
-			return new AjaxResult(SC_BAD_REQUEST, "'id'를 입력해주세요");
+			return AjaxResult.requireParameter("id");
 		}
 		mvo.setId(id);
 
-		// 파라미터에 'pwd'가 없으면 SC_BAD_REQUEST 를 반환
+		// 'pwd' 파라미터가 없는 경우
 		String pwd = request.getParameter("pwd");
 		if (pwd == null || pwd.equals("")) {
-			return new AjaxResult(SC_BAD_REQUEST, "'pwd'를 입력해주세요");
+			return AjaxResult.requireParameter("pwd");
 		}
 		mvo.setPwd(pwd);
 
-		// 파라미터에 'email'가 없으면 SC_BAD_REQUEST 를 반환
+		// 'email' 파라미터가 없는 경우
 		String email = request.getParameter("email");
 		if (email == null || email.equals("")) {
-			return new AjaxResult(SC_BAD_REQUEST, "'email'를 입력해주세요");
+			return AjaxResult.requireParameter("email");
 		}
 		mvo.setEmail(email);
 
-		// 파라미터에 'pwd'가 없으면 SC_BAD_REQUEST 를 반환
+		// 'phone' 파라미터가 없는 경우
 		String phone = request.getParameter("phone");
 		if (phone == null || phone.equals("")) {
-			return new AjaxResult(SC_BAD_REQUEST, "'phone'를 입력해주세요");
+			return AjaxResult.requireParameter("phone");
 		}
 		mvo.setPhone(phone);
 
-		// 회원가입 실패 시 SC_INTERNAL_SERVER_ERROR 를 반환
+		// 회원가입에 실패한 경우
 		if (MemberDao.getInstance().insertMember(mvo) == 0) {
-			return new AjaxResult(SC_INTERNAL_SERVER_ERROR, "회원가입 실패\n관리자에게 문의하세요");
+			return AjaxResult.fail("회원가입에 실패하였습니다");
 		}
 
 		// 돌아갈 페이지 정보를 확인하고, 없으면 index 페이지로 이동
@@ -65,8 +61,8 @@ public class JoinAjaxAction extends AjaxAction {
 			returnUrl = UrlUtil.decode(returnUrlParam);
 		}
 
-		// 돌아갈 페이지 정보와 함께 SC_OK 를 반환
-		return new AjaxResult(SC_OK, "회원가입에 성공하였습니다", returnUrl);
+		// 돌아갈 페이지 정보와 함께 성공 메시지를 반환
+		return AjaxResult.success("회원가입이 완료되었습니다", returnUrl);
 	}
 
 }

--- a/src/main/java/com/team4/museum/controller/action/member/LoginAction.java
+++ b/src/main/java/com/team4/museum/controller/action/member/LoginAction.java
@@ -6,25 +6,19 @@ import static com.team4.museum.util.AjaxResult.OK;
 
 import java.io.IOException;
 
-import com.team4.museum.controller.action.Action;
+import com.team4.museum.controller.action.AjaxAction;
 import com.team4.museum.dao.MemberDao;
 import com.team4.museum.util.AjaxResult;
 import com.team4.museum.util.UrlUtil;
 import com.team4.museum.vo.MemberVO;
 
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 
-public class LoginAction implements Action {
+public class LoginAction extends AjaxAction {
 
-	@Override
-	public void execute(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-		getResult(request, response).applyToResponse(response);
-	}
-
-	private AjaxResult getResult(HttpServletRequest request, HttpServletResponse response) {
+	protected AjaxResult handleAjaxRequest(HttpServletRequest request, HttpServletResponse response) {
 		// 파라미터에 'id'가 없으면 BAD_REQUEST 를 반환
 		String id = request.getParameter("id");
 		if (id == null || id.equals("")) {

--- a/src/main/java/com/team4/museum/controller/action/member/LoginAjaxAction.java
+++ b/src/main/java/com/team4/museum/controller/action/member/LoginAjaxAction.java
@@ -16,7 +16,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 
-public class LoginAction extends AjaxAction {
+public class LoginAjaxAction extends AjaxAction {
 
 	protected AjaxResult handleAjaxRequest(HttpServletRequest request, HttpServletResponse response) {
 		// 파라미터에 'id'가 없으면 BAD_REQUEST 를 반환

--- a/src/main/java/com/team4/museum/controller/action/member/LoginAjaxAction.java
+++ b/src/main/java/com/team4/museum/controller/action/member/LoginAjaxAction.java
@@ -18,24 +18,24 @@ public class LoginAjaxAction extends AjaxAction {
 		// 'id' 파라미터가 없는 경우
 		String id = request.getParameter("id");
 		if (id == null || id.equals("")) {
-			return AjaxResult.requireParameter("id");
+			return requireParameter("id");
 		}
 
 		// 'pwd' 파라미터가 없는 경우
 		String pwd = request.getParameter("pwd");
 		if (pwd == null || pwd.equals("")) {
-			return AjaxResult.requireParameter("pwd");
+			return requireParameter("pwd");
 		}
 
 		// 입력된 'id'에 해당하는 사용자 계정이 없는 경우
 		MemberVO mvo = MemberDao.getInstance().getMember(id);
 		if (mvo == null) {
-			return AjaxResult.notFound("존재하지 않는 아이디입니다");
+			return notFound("존재하지 않는 아이디입니다");
 		}
 
 		// 입력된 'pwd'가 사용자 계정의 비밀번호와 일치하지 않는 경우
 		if (!mvo.getPwd().equals(pwd)) {
-			return AjaxResult.badRequest("비밀번호가 일치하지 않습니다");
+			return badRequest("비밀번호가 일치하지 않습니다");
 		}
 
 		// 로그인 성공 시 세션에 로그인 정보를 저장
@@ -50,7 +50,7 @@ public class LoginAjaxAction extends AjaxAction {
 		}
 
 		// 돌아갈 페이지 정보와 함께 성공 메시지를 반환
-		return AjaxResult.success("로그인에 성공하였습니다", returnUrl);
+		return ok("로그인에 성공하였습니다", returnUrl);
 	}
 
 	/**

--- a/src/main/java/com/team4/museum/controller/action/member/LoginAjaxAction.java
+++ b/src/main/java/com/team4/museum/controller/action/member/LoginAjaxAction.java
@@ -1,9 +1,5 @@
 package com.team4.museum.controller.action.member;
 
-import static jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
-import static jakarta.servlet.http.HttpServletResponse.SC_NOT_FOUND;
-import static jakarta.servlet.http.HttpServletResponse.SC_OK;
-
 import java.io.IOException;
 
 import com.team4.museum.controller.action.AjaxAction;
@@ -19,31 +15,30 @@ import jakarta.servlet.http.HttpSession;
 public class LoginAjaxAction extends AjaxAction {
 
 	protected AjaxResult handleAjaxRequest(HttpServletRequest request, HttpServletResponse response) {
-		// 파라미터에 'id'가 없으면 SC_BAD_REQUEST 를 반환
+		// 'id' 파라미터가 없는 경우
 		String id = request.getParameter("id");
 		if (id == null || id.equals("")) {
-			return new AjaxResult(SC_BAD_REQUEST, "'id'를 입력해주세요");
+			return AjaxResult.requireParameter("id");
 		}
 
-		// 파라미터에 'pwd'가 없으면 SC_BAD_REQUEST 를 반환
+		// 'pwd' 파라미터가 없는 경우
 		String pwd = request.getParameter("pwd");
 		if (pwd == null || pwd.equals("")) {
-			return new AjaxResult(SC_BAD_REQUEST, "'pwd'를 입력해주세요");
+			return AjaxResult.requireParameter("pwd");
 		}
 
-		// 'id'에 해당하는 'MemberVO'가 없으면 SC_NOT_FOUND 를 반환
+		// 입력된 'id'에 해당하는 사용자 계정이 없는 경우
 		MemberVO mvo = MemberDao.getInstance().getMember(id);
 		if (mvo == null) {
-			return new AjaxResult(SC_NOT_FOUND, "존재하지 않는 아이디입니다");
+			return AjaxResult.notFound("존재하지 않는 아이디입니다");
 		}
 
-		// 'pwd'가 비밀번호와 다르면 SC_BAD_REQUEST 를 반환
+		// 입력된 'pwd'가 사용자 계정의 비밀번호와 일치하지 않는 경우
 		if (!mvo.getPwd().equals(pwd)) {
-			return new AjaxResult(SC_BAD_REQUEST, "잘못된 비밀번호입니다");
+			return AjaxResult.badRequest("비밀번호가 일치하지 않습니다");
 		}
 
-		// 로그인 성공 시
-		// 세션에 로그인 정보를 저장
+		// 로그인 성공 시 세션에 로그인 정보를 저장
 		HttpSession session = request.getSession();
 		session.setAttribute("loginUser", mvo);
 
@@ -54,8 +49,8 @@ public class LoginAjaxAction extends AjaxAction {
 			returnUrl = UrlUtil.decode(returnUrlParam);
 		}
 
-		// 돌아갈 페이지 정보와 함께 SC_OK 를 반환
-		return new AjaxResult(SC_OK, "로그인에 성공하였습니다", returnUrl);
+		// 돌아갈 페이지 정보와 함께 성공 메시지를 반환
+		return AjaxResult.success("로그인에 성공하였습니다", returnUrl);
 	}
 
 	/**

--- a/src/main/java/com/team4/museum/controller/action/member/LoginAjaxAction.java
+++ b/src/main/java/com/team4/museum/controller/action/member/LoginAjaxAction.java
@@ -1,8 +1,8 @@
 package com.team4.museum.controller.action.member;
 
-import static com.team4.museum.util.AjaxResult.BAD_REQUEST;
-import static com.team4.museum.util.AjaxResult.NOT_FOUND;
-import static com.team4.museum.util.AjaxResult.OK;
+import static jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static jakarta.servlet.http.HttpServletResponse.SC_NOT_FOUND;
+import static jakarta.servlet.http.HttpServletResponse.SC_OK;
 
 import java.io.IOException;
 
@@ -19,27 +19,27 @@ import jakarta.servlet.http.HttpSession;
 public class LoginAjaxAction extends AjaxAction {
 
 	protected AjaxResult handleAjaxRequest(HttpServletRequest request, HttpServletResponse response) {
-		// 파라미터에 'id'가 없으면 BAD_REQUEST 를 반환
+		// 파라미터에 'id'가 없으면 SC_BAD_REQUEST 를 반환
 		String id = request.getParameter("id");
 		if (id == null || id.equals("")) {
-			return new AjaxResult(BAD_REQUEST, "'id'를 입력해주세요");
+			return new AjaxResult(SC_BAD_REQUEST, "'id'를 입력해주세요");
 		}
 
-		// 파라미터에 'pwd'가 없으면 BAD_REQUEST 를 반환
+		// 파라미터에 'pwd'가 없으면 SC_BAD_REQUEST 를 반환
 		String pwd = request.getParameter("pwd");
 		if (pwd == null || pwd.equals("")) {
-			return new AjaxResult(BAD_REQUEST, "'pwd'를 입력해주세요");
+			return new AjaxResult(SC_BAD_REQUEST, "'pwd'를 입력해주세요");
 		}
 
-		// 'id'에 해당하는 'MemberVO'가 없으면 NOT_FOUND 를 반환
+		// 'id'에 해당하는 'MemberVO'가 없으면 SC_NOT_FOUND 를 반환
 		MemberVO mvo = MemberDao.getInstance().getMember(id);
 		if (mvo == null) {
-			return new AjaxResult(NOT_FOUND, "존재하지 않는 아이디입니다");
+			return new AjaxResult(SC_NOT_FOUND, "존재하지 않는 아이디입니다");
 		}
 
-		// 'pwd'가 비밀번호와 다르면 BAD_REQUEST 를 반환
+		// 'pwd'가 비밀번호와 다르면 SC_BAD_REQUEST 를 반환
 		if (!mvo.getPwd().equals(pwd)) {
-			return new AjaxResult(BAD_REQUEST, "잘못된 비밀번호입니다");
+			return new AjaxResult(SC_BAD_REQUEST, "잘못된 비밀번호입니다");
 		}
 
 		// 로그인 성공 시
@@ -54,8 +54,8 @@ public class LoginAjaxAction extends AjaxAction {
 			returnUrl = UrlUtil.decode(returnUrlParam);
 		}
 
-		// 돌아갈 페이지 정보와 함께 OK 를 반환
-		return new AjaxResult(OK, "로그인에 성공하였습니다", returnUrl);
+		// 돌아갈 페이지 정보와 함께 SC_OK 를 반환
+		return new AjaxResult(SC_OK, "로그인에 성공하였습니다", returnUrl);
 	}
 
 	/**

--- a/src/main/java/com/team4/museum/controller/action/member/LogoutAction.java
+++ b/src/main/java/com/team4/museum/controller/action/member/LogoutAction.java
@@ -2,24 +2,16 @@ package com.team4.museum.controller.action.member;
 
 import static com.team4.museum.util.AjaxResult.OK;
 
-import java.io.IOException;
-
-import com.team4.museum.controller.action.Action;
+import com.team4.museum.controller.action.AjaxAction;
 import com.team4.museum.util.AjaxResult;
 import com.team4.museum.util.UrlUtil;
 
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-public class LogoutAction implements Action {
+public class LogoutAction extends AjaxAction {
 
-	@Override
-	public void execute(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-		getResult(request, response).applyToResponse(response);
-	}
-
-	private AjaxResult getResult(HttpServletRequest request, HttpServletResponse response) {
+	protected AjaxResult handleAjaxRequest(HttpServletRequest request, HttpServletResponse response) {
 		request.getSession().removeAttribute("loginUser");
 
 		// 돌아갈 페이지 정보를 확인하고, 없으면 index 페이지로 이동

--- a/src/main/java/com/team4/museum/controller/action/member/LogoutAjaxAction.java
+++ b/src/main/java/com/team4/museum/controller/action/member/LogoutAjaxAction.java
@@ -1,7 +1,5 @@
 package com.team4.museum.controller.action.member;
 
-import static jakarta.servlet.http.HttpServletResponse.SC_OK;
-
 import com.team4.museum.controller.action.AjaxAction;
 import com.team4.museum.util.AjaxResult;
 import com.team4.museum.util.UrlUtil;
@@ -21,8 +19,8 @@ public class LogoutAjaxAction extends AjaxAction {
 			returnUrl = UrlUtil.decode(returnUrlParam);
 		}
 
-		// 돌아갈 페이지 정보와 함께 SC_OK 를 반환
-		return new AjaxResult(SC_OK, "로그아웃 되었습니다", returnUrl);
+		// 돌아갈 페이지 정보와 함께 성공 메시지를 반환
+		return AjaxResult.success("로그아웃 되었습니다", returnUrl);
 	}
 
 }

--- a/src/main/java/com/team4/museum/controller/action/member/LogoutAjaxAction.java
+++ b/src/main/java/com/team4/museum/controller/action/member/LogoutAjaxAction.java
@@ -1,6 +1,6 @@
 package com.team4.museum.controller.action.member;
 
-import static com.team4.museum.util.AjaxResult.OK;
+import static jakarta.servlet.http.HttpServletResponse.SC_OK;
 
 import com.team4.museum.controller.action.AjaxAction;
 import com.team4.museum.util.AjaxResult;
@@ -21,8 +21,8 @@ public class LogoutAjaxAction extends AjaxAction {
 			returnUrl = UrlUtil.decode(returnUrlParam);
 		}
 
-		// 돌아갈 페이지 정보와 함께 OK 를 반환
-		return new AjaxResult(OK, "로그아웃 되었습니다", returnUrl);
+		// 돌아갈 페이지 정보와 함께 SC_OK 를 반환
+		return new AjaxResult(SC_OK, "로그아웃 되었습니다", returnUrl);
 	}
 
 }

--- a/src/main/java/com/team4/museum/controller/action/member/LogoutAjaxAction.java
+++ b/src/main/java/com/team4/museum/controller/action/member/LogoutAjaxAction.java
@@ -20,7 +20,7 @@ public class LogoutAjaxAction extends AjaxAction {
 		}
 
 		// 돌아갈 페이지 정보와 함께 성공 메시지를 반환
-		return AjaxResult.success("로그아웃 되었습니다", returnUrl);
+		return ok("로그아웃 되었습니다", returnUrl);
 	}
 
 }

--- a/src/main/java/com/team4/museum/controller/action/member/LogoutAjaxAction.java
+++ b/src/main/java/com/team4/museum/controller/action/member/LogoutAjaxAction.java
@@ -9,7 +9,7 @@ import com.team4.museum.util.UrlUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-public class LogoutAction extends AjaxAction {
+public class LogoutAjaxAction extends AjaxAction {
 
 	protected AjaxResult handleAjaxRequest(HttpServletRequest request, HttpServletResponse response) {
 		request.getSession().removeAttribute("loginUser");

--- a/src/main/java/com/team4/museum/controller/action/member/MyPageAction.java
+++ b/src/main/java/com/team4/museum/controller/action/member/MyPageAction.java
@@ -1,5 +1,7 @@
 package com.team4.museum.controller.action.member;
 
+import static com.team4.museum.controller.action.member.LoginAjaxAction.isLogined;
+
 import java.io.IOException;
 
 import com.team4.museum.controller.action.Action;
@@ -12,7 +14,7 @@ public class MyPageAction implements Action {
 
 	@Override
 	public void execute(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-		if (LoginAction.isLogined(request, response)) {
+		if (isLogined(request, response)) {
 			request.getRequestDispatcher("member/mypage.jsp").forward(request, response);
 		}
 	}

--- a/src/main/java/com/team4/museum/controller/action/member/MyPageEditAction.java
+++ b/src/main/java/com/team4/museum/controller/action/member/MyPageEditAction.java
@@ -1,5 +1,7 @@
 package com.team4.museum.controller.action.member;
 
+import static com.team4.museum.controller.action.member.LoginAjaxAction.getLoginUser;
+
 import java.io.IOException;
 
 import com.team4.museum.controller.action.Action;
@@ -13,7 +15,7 @@ import jakarta.servlet.http.HttpServletResponse;
 public class MyPageEditAction implements Action {
 
 	public void execute(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-		MemberVO mvo = LoginAction.getLoginUser(request, response);
+		MemberVO mvo = getLoginUser(request, response);
 		if (mvo == null) {
 			return;
 		}

--- a/src/main/java/com/team4/museum/controller/action/member/MyPageEditFormAction.java
+++ b/src/main/java/com/team4/museum/controller/action/member/MyPageEditFormAction.java
@@ -1,5 +1,7 @@
 package com.team4.museum.controller.action.member;
 
+import static com.team4.museum.controller.action.member.LoginAjaxAction.isLogined;
+
 import java.io.IOException;
 
 import com.team4.museum.controller.action.Action;
@@ -11,7 +13,7 @@ import jakarta.servlet.http.HttpServletResponse;
 public class MyPageEditFormAction implements Action {
 
 	public void execute(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-		if (LoginAction.isLogined(request, response)) {
+		if (isLogined(request, response)) {
 			request.getRequestDispatcher("member/mypageEditForm.jsp").forward(request, response);
 		}
 	}

--- a/src/main/java/com/team4/museum/controller/action/member/MyPageFavoriteAction.java
+++ b/src/main/java/com/team4/museum/controller/action/member/MyPageFavoriteAction.java
@@ -8,7 +8,7 @@ import static com.team4.museum.util.AjaxResult.UNAUTHORIZED;
 
 import java.io.IOException;
 
-import com.team4.museum.controller.action.Action;
+import com.team4.museum.controller.action.AjaxAction;
 import com.team4.museum.dao.FavoriteDao;
 import com.team4.museum.util.AjaxResult;
 import com.team4.museum.vo.MemberVO;
@@ -17,14 +17,10 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-public class MyPageFavoriteAction implements Action {
+public class MyPageFavoriteAction extends AjaxAction {
 
-	@Override
-	public void execute(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-		getResult(request, response).applyToResponse(response);
-	}
-
-	private AjaxResult getResult(HttpServletRequest request, HttpServletResponse response) throws IOException {
+	protected AjaxResult handleAjaxRequest(HttpServletRequest request, HttpServletResponse response)
+			throws IOException {
 		// 파라미터에 'aseq'가 없거나 정수가 아니면 BAD_REQUEST 를 반환
 		String aseq = request.getParameter("aseq");
 		if (aseq == null || aseq.equals("") || !aseq.matches("^[0-9]*$")) {

--- a/src/main/java/com/team4/museum/controller/action/member/MyPageFavoriteAjaxAction.java
+++ b/src/main/java/com/team4/museum/controller/action/member/MyPageFavoriteAjaxAction.java
@@ -1,7 +1,7 @@
 package com.team4.museum.controller.action.member;
 
-import static com.team4.museum.controller.action.member.LoginAction.getLoginUrl;
-import static com.team4.museum.controller.action.member.LoginAction.getLoginUserFrom;
+import static com.team4.museum.controller.action.member.LoginAjaxAction.getLoginUrl;
+import static com.team4.museum.controller.action.member.LoginAjaxAction.getLoginUserFrom;
 import static com.team4.museum.util.AjaxResult.BAD_REQUEST;
 import static com.team4.museum.util.AjaxResult.OK;
 import static com.team4.museum.util.AjaxResult.UNAUTHORIZED;
@@ -13,11 +13,10 @@ import com.team4.museum.dao.FavoriteDao;
 import com.team4.museum.util.AjaxResult;
 import com.team4.museum.vo.MemberVO;
 
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-public class MyPageFavoriteAction extends AjaxAction {
+public class MyPageFavoriteAjaxAction extends AjaxAction {
 
 	protected AjaxResult handleAjaxRequest(HttpServletRequest request, HttpServletResponse response)
 			throws IOException {

--- a/src/main/java/com/team4/museum/controller/action/member/MyPageFavoriteAjaxAction.java
+++ b/src/main/java/com/team4/museum/controller/action/member/MyPageFavoriteAjaxAction.java
@@ -2,9 +2,6 @@ package com.team4.museum.controller.action.member;
 
 import static com.team4.museum.controller.action.member.LoginAjaxAction.getLoginUrl;
 import static com.team4.museum.controller.action.member.LoginAjaxAction.getLoginUserFrom;
-import static jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
-import static jakarta.servlet.http.HttpServletResponse.SC_OK;
-import static jakarta.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
 
 import java.io.IOException;
 
@@ -24,21 +21,21 @@ public class MyPageFavoriteAjaxAction extends AjaxAction {
 		String aseq = request.getParameter("aseq");
 		if (aseq == null || aseq.equals("") || !aseq.matches("^[0-9]*$")) {
 			// 사용자 입력이 아니므로 어떤 요소가 잘못되었는지 알려줄 필요가 없음
-			return new AjaxResult(SC_BAD_REQUEST, "잘못된 요청입니다");
+			return AjaxResult.badRequest();
 		}
 
 		// 로그인이 되어있지 않으면 SC_UNAUTHORIZED 를 반환
 		MemberVO mvo = getLoginUserFrom(request);
 		if (mvo == null) {
 			String returnUrl = "museum.do?command=artworkView&aseq=" + aseq;
-			return new AjaxResult(SC_UNAUTHORIZED, "로그인이 필요합니다", getLoginUrl(returnUrl));
+			return AjaxResult.unauthorized("로그인이 필요합니다", getLoginUrl(returnUrl));
 		}
 
 		FavoriteDao fdao = FavoriteDao.getInstance();
 		Boolean result = fdao.toggleFavorite(mvo.getId(), Integer.parseInt(aseq));
 
-		// 즐겨찾기 추가/삭제 결과에 따라 메시지와 함께 SC_OK 를 반환
-		return new AjaxResult(SC_OK, result ? "즐겨찾기에 추가되었습니다" : "즐겨찾기에서 삭제되었습니다");
+		// 즐겨찾기 추가/삭제 결과에 따라 메시지와 함께 성공 메시지를 반환
+		return AjaxResult.success(result ? "즐겨찾기 목록에 추가되었습니다" : "즐겨찾기 목록에서 삭제되었습니다");
 	}
 
 }

--- a/src/main/java/com/team4/museum/controller/action/member/MyPageFavoriteAjaxAction.java
+++ b/src/main/java/com/team4/museum/controller/action/member/MyPageFavoriteAjaxAction.java
@@ -2,9 +2,9 @@ package com.team4.museum.controller.action.member;
 
 import static com.team4.museum.controller.action.member.LoginAjaxAction.getLoginUrl;
 import static com.team4.museum.controller.action.member.LoginAjaxAction.getLoginUserFrom;
-import static com.team4.museum.util.AjaxResult.BAD_REQUEST;
-import static com.team4.museum.util.AjaxResult.OK;
-import static com.team4.museum.util.AjaxResult.UNAUTHORIZED;
+import static jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static jakarta.servlet.http.HttpServletResponse.SC_OK;
+import static jakarta.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
 
 import java.io.IOException;
 
@@ -20,25 +20,25 @@ public class MyPageFavoriteAjaxAction extends AjaxAction {
 
 	protected AjaxResult handleAjaxRequest(HttpServletRequest request, HttpServletResponse response)
 			throws IOException {
-		// 파라미터에 'aseq'가 없거나 정수가 아니면 BAD_REQUEST 를 반환
+		// 파라미터에 'aseq'가 없거나 정수가 아니면 SC_BAD_REQUEST 를 반환
 		String aseq = request.getParameter("aseq");
 		if (aseq == null || aseq.equals("") || !aseq.matches("^[0-9]*$")) {
 			// 사용자 입력이 아니므로 어떤 요소가 잘못되었는지 알려줄 필요가 없음
-			return new AjaxResult(BAD_REQUEST, "잘못된 요청입니다");
+			return new AjaxResult(SC_BAD_REQUEST, "잘못된 요청입니다");
 		}
 
-		// 로그인이 되어있지 않으면 UNAUTHORIZED 를 반환
+		// 로그인이 되어있지 않으면 SC_UNAUTHORIZED 를 반환
 		MemberVO mvo = getLoginUserFrom(request);
 		if (mvo == null) {
 			String returnUrl = "museum.do?command=artworkView&aseq=" + aseq;
-			return new AjaxResult(UNAUTHORIZED, "로그인이 필요합니다", getLoginUrl(returnUrl));
+			return new AjaxResult(SC_UNAUTHORIZED, "로그인이 필요합니다", getLoginUrl(returnUrl));
 		}
 
 		FavoriteDao fdao = FavoriteDao.getInstance();
 		Boolean result = fdao.toggleFavorite(mvo.getId(), Integer.parseInt(aseq));
 
-		// 즐겨찾기 추가/삭제 결과에 따라 메시지와 함께 OK 를 반환
-		return new AjaxResult(OK, result ? "즐겨찾기에 추가되었습니다" : "즐겨찾기에서 삭제되었습니다");
+		// 즐겨찾기 추가/삭제 결과에 따라 메시지와 함께 SC_OK 를 반환
+		return new AjaxResult(SC_OK, result ? "즐겨찾기에 추가되었습니다" : "즐겨찾기에서 삭제되었습니다");
 	}
 
 }

--- a/src/main/java/com/team4/museum/controller/action/member/MyPageFavoriteAjaxAction.java
+++ b/src/main/java/com/team4/museum/controller/action/member/MyPageFavoriteAjaxAction.java
@@ -21,21 +21,21 @@ public class MyPageFavoriteAjaxAction extends AjaxAction {
 		String aseq = request.getParameter("aseq");
 		if (aseq == null || aseq.equals("") || !aseq.matches("^[0-9]*$")) {
 			// 사용자 입력이 아니므로 어떤 요소가 잘못되었는지 알려줄 필요가 없음
-			return AjaxResult.badRequest();
+			return badRequest();
 		}
 
 		// 로그인이 되어있지 않으면 SC_UNAUTHORIZED 를 반환
 		MemberVO mvo = getLoginUserFrom(request);
 		if (mvo == null) {
 			String returnUrl = "museum.do?command=artworkView&aseq=" + aseq;
-			return AjaxResult.unauthorized("로그인이 필요합니다", getLoginUrl(returnUrl));
+			return unauthorized("로그인이 필요합니다", getLoginUrl(returnUrl));
 		}
 
 		FavoriteDao fdao = FavoriteDao.getInstance();
 		Boolean result = fdao.toggleFavorite(mvo.getId(), Integer.parseInt(aseq));
 
 		// 즐겨찾기 추가/삭제 결과에 따라 메시지와 함께 성공 메시지를 반환
-		return AjaxResult.success(result ? "즐겨찾기 목록에 추가되었습니다" : "즐겨찾기 목록에서 삭제되었습니다");
+		return ok(result ? "즐겨찾기 목록에 추가되었습니다" : "즐겨찾기 목록에서 삭제되었습니다");
 	}
 
 }

--- a/src/main/java/com/team4/museum/controller/action/notice/InsertNoticeAction.java
+++ b/src/main/java/com/team4/museum/controller/action/notice/InsertNoticeAction.java
@@ -1,11 +1,12 @@
 package com.team4.museum.controller.action.notice;
 
+import static com.team4.museum.controller.action.member.LoginAjaxAction.getLoginUser;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.Calendar;
 
 import com.team4.museum.controller.action.Action;
-import com.team4.museum.controller.action.member.LoginAction;
 import com.team4.museum.dao.NoticeDao;
 import com.team4.museum.vo.MemberVO;
 import com.team4.museum.vo.NoticeVO;
@@ -25,7 +26,7 @@ public class InsertNoticeAction implements Action {
 		NoticeVO nvo = new NoticeVO();
 
 		HttpSession session = request.getSession();
-		MemberVO mvo = LoginAction.getLoginUser(request, response);
+		MemberVO mvo = getLoginUser(request, response);
 		if (mvo == null) {
 			return;
 		}

--- a/src/main/java/com/team4/museum/controller/action/notice/UpdateNoticeAction.java
+++ b/src/main/java/com/team4/museum/controller/action/notice/UpdateNoticeAction.java
@@ -1,11 +1,12 @@
 package com.team4.museum.controller.action.notice;
 
+import static com.team4.museum.controller.action.member.LoginAjaxAction.getLoginUser;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.Calendar;
 
 import com.team4.museum.controller.action.Action;
-import com.team4.museum.controller.action.member.LoginAction;
 import com.team4.museum.dao.NoticeDao;
 import com.team4.museum.vo.MemberVO;
 import com.team4.museum.vo.NoticeVO;
@@ -24,7 +25,7 @@ public class UpdateNoticeAction implements Action {
 		NoticeDao ndao = NoticeDao.getInstance();
 		NoticeVO nvo = new NoticeVO();
 
-		MemberVO mvo = LoginAction.getLoginUser(request, response);
+		MemberVO mvo = getLoginUser(request, response);
 		if (mvo == null) { // 조건을 달아준다.
 			return;
 		}

--- a/src/main/java/com/team4/museum/controller/action/qna/QnaPwdCheckAction.java
+++ b/src/main/java/com/team4/museum/controller/action/qna/QnaPwdCheckAction.java
@@ -5,27 +5,19 @@ import static com.team4.museum.util.AjaxResult.NO_CONTENT;
 import static com.team4.museum.util.AjaxResult.OK;
 import static com.team4.museum.util.AjaxResult.UNAUTHORIZED;
 
-import java.io.IOException;
-
-import com.team4.museum.controller.action.Action;
+import com.team4.museum.controller.action.AjaxAction;
 import com.team4.museum.controller.action.member.LoginAction;
 import com.team4.museum.dao.QnaDao;
 import com.team4.museum.util.AjaxResult;
 import com.team4.museum.vo.QnaVO;
 
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 
-public class QnaPwdCheckAction implements Action {
+public class QnaPwdCheckAction extends AjaxAction {
 
-	@Override
-	public void execute(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-		getResult(request, response).applyToResponse(response);
-	}
-
-	private AjaxResult getResult(HttpServletRequest request, HttpServletResponse response) {
+	protected AjaxResult handleAjaxRequest(HttpServletRequest request, HttpServletResponse response) {
 		// 파라미터에 'qseq'가 없으면 BAD_REQUEST 를 반환
 		String qseqStr = request.getParameter("qseq");
 		if (qseqStr == null || qseqStr.equals("") || !qseqStr.matches("^[0-9]*$")) {

--- a/src/main/java/com/team4/museum/controller/action/qna/QnaPwdCheckAjaxAction.java
+++ b/src/main/java/com/team4/museum/controller/action/qna/QnaPwdCheckAjaxAction.java
@@ -1,10 +1,10 @@
 package com.team4.museum.controller.action.qna;
 
 import static com.team4.museum.controller.action.member.LoginAjaxAction.isAdmin;
-import static com.team4.museum.util.AjaxResult.BAD_REQUEST;
-import static com.team4.museum.util.AjaxResult.NO_CONTENT;
-import static com.team4.museum.util.AjaxResult.OK;
-import static com.team4.museum.util.AjaxResult.UNAUTHORIZED;
+import static jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static jakarta.servlet.http.HttpServletResponse.SC_NO_CONTENT;
+import static jakarta.servlet.http.HttpServletResponse.SC_OK;
+import static jakarta.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
 
 import com.team4.museum.controller.action.AjaxAction;
 import com.team4.museum.dao.QnaDao;
@@ -18,10 +18,10 @@ import jakarta.servlet.http.HttpSession;
 public class QnaPwdCheckAjaxAction extends AjaxAction {
 
 	protected AjaxResult handleAjaxRequest(HttpServletRequest request, HttpServletResponse response) {
-		// 파라미터에 'qseq'가 없으면 BAD_REQUEST 를 반환
+		// 파라미터에 'qseq'가 없으면 SC_BAD_REQUEST 를 반환
 		String qseqStr = request.getParameter("qseq");
 		if (qseqStr == null || qseqStr.equals("") || !qseqStr.matches("^[0-9]*$")) {
-			return new AjaxResult(BAD_REQUEST, "'qseq'를 입력해주세요");
+			return new AjaxResult(SC_BAD_REQUEST, "'qseq'를 입력해주세요");
 		}
 
 		int qseq = Integer.parseInt(qseqStr);
@@ -29,9 +29,9 @@ public class QnaPwdCheckAjaxAction extends AjaxAction {
 		QnaVO qnaVO = qdao.getQna(qseq);
 		request.setAttribute("qseq", qseq);
 
-		// 'qseq' 파라미터에 해당하는 'QnaVO'가 없으면 NO_CONTENT 를 반환
+		// 'qseq' 파라미터에 해당하는 'QnaVO'가 없으면 SC_NO_CONTENT 를 반환
 		if (qnaVO == null) {
-			return new AjaxResult(NO_CONTENT, "존재하지 않는 문의입니다");
+			return new AjaxResult(SC_NO_CONTENT, "존재하지 않는 문의입니다");
 		}
 
 		HttpSession session = request.getSession();
@@ -40,43 +40,43 @@ public class QnaPwdCheckAjaxAction extends AjaxAction {
 		case "view":
 			url = "museum.do?command=qnaView&qseq=" + qseqStr;
 
-			// 'qnaVO'가 공개 상태면 OK 를 반환
+			// 'qnaVO'가 공개 상태면 SC_OK 를 반환
 			if (qnaVO.isPublic()) {
-				return new AjaxResult(OK, "공개된 문의입니다", url);
+				return new AjaxResult(SC_OK, "공개된 문의입니다", url);
 			}
 
-			// 관리자 일 경우 OK 를 반환
+			// 관리자 일 경우 SC_OK 를 반환
 			if (isAdmin(request)) {
-				return new AjaxResult(OK, "관리자로 확인되었습니다", url);
+				return new AjaxResult(SC_OK, "관리자로 확인되었습니다", url);
 			}
 			break;
 		case "edit":
 			url = "museum.do?command=qnaWriteForm&qseq=" + qseqStr;
 			break;
 		default:
-			// 'mode'가 'view'나 'edit'가 아니면 BAD_REQUEST 를 반환
-			return new AjaxResult(BAD_REQUEST, "'mode' 파라미터가 'view'나 'edit'가 아닙니다");
+			// 'mode'가 'view'나 'edit'가 아니면 SC_BAD_REQUEST 를 반환
+			return new AjaxResult(SC_BAD_REQUEST, "'mode' 파라미터가 'view'나 'edit'가 아닙니다");
 		}
 
-		// 세션에 비밀번호 확인 기록이 있는 경우 OK 를 반환
+		// 세션에 비밀번호 확인 기록이 있는 경우 SC_OK 를 반환
 		if (session.getAttribute("qnaPass" + qseq) != null) {
-			return new AjaxResult(OK, "비밀번호 확인 기록이 존재합니다", url);
+			return new AjaxResult(SC_OK, "비밀번호 확인 기록이 존재합니다", url);
 		}
 
-		// 'pwd' 파라미터가 없으면 UNAUTHORIZED 를 반환
+		// 'pwd' 파라미터가 없으면 SC_UNAUTHORIZED 를 반환
 		String pwd = request.getParameter("pwd");
 		if (pwd == null || pwd.trim().equals("")) {
-			return new AjaxResult(UNAUTHORIZED, "'pwd'를 입력해주세요");
+			return new AjaxResult(SC_UNAUTHORIZED, "'pwd'를 입력해주세요");
 		}
 
-		// 'pwd'가 비밀번호와 같으면 세션에 비밀번호 확인 기록을 남기고 OK 를 반환
+		// 'pwd'가 비밀번호와 같으면 세션에 비밀번호 확인 기록을 남기고 SC_OK 를 반환
 		if (qnaVO.getPwd().equals(pwd)) {
 			session.setAttribute("qnaPass" + qseq, qseq);
-			return new AjaxResult(OK, "비밀번호가 확인되었습니다", url);
+			return new AjaxResult(SC_OK, "비밀번호가 확인되었습니다", url);
 		}
 
-		// 비밀번호가 틀리면 BAD_REQUEST 를 반환
-		return new AjaxResult(BAD_REQUEST, "잘못된 비밀번호입니다");
+		// 비밀번호가 틀리면 SC_BAD_REQUEST 를 반환
+		return new AjaxResult(SC_BAD_REQUEST, "잘못된 비밀번호입니다");
 	}
 
 }

--- a/src/main/java/com/team4/museum/controller/action/qna/QnaPwdCheckAjaxAction.java
+++ b/src/main/java/com/team4/museum/controller/action/qna/QnaPwdCheckAjaxAction.java
@@ -1,12 +1,12 @@
 package com.team4.museum.controller.action.qna;
 
+import static com.team4.museum.controller.action.member.LoginAjaxAction.isAdmin;
 import static com.team4.museum.util.AjaxResult.BAD_REQUEST;
 import static com.team4.museum.util.AjaxResult.NO_CONTENT;
 import static com.team4.museum.util.AjaxResult.OK;
 import static com.team4.museum.util.AjaxResult.UNAUTHORIZED;
 
 import com.team4.museum.controller.action.AjaxAction;
-import com.team4.museum.controller.action.member.LoginAction;
 import com.team4.museum.dao.QnaDao;
 import com.team4.museum.util.AjaxResult;
 import com.team4.museum.vo.QnaVO;
@@ -15,7 +15,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 
-public class QnaPwdCheckAction extends AjaxAction {
+public class QnaPwdCheckAjaxAction extends AjaxAction {
 
 	protected AjaxResult handleAjaxRequest(HttpServletRequest request, HttpServletResponse response) {
 		// 파라미터에 'qseq'가 없으면 BAD_REQUEST 를 반환
@@ -46,7 +46,7 @@ public class QnaPwdCheckAction extends AjaxAction {
 			}
 
 			// 관리자 일 경우 OK 를 반환
-			if (LoginAction.isAdmin(request)) {
+			if (isAdmin(request)) {
 				return new AjaxResult(OK, "관리자로 확인되었습니다", url);
 			}
 			break;

--- a/src/main/java/com/team4/museum/controller/action/qna/QnaPwdCheckAjaxAction.java
+++ b/src/main/java/com/team4/museum/controller/action/qna/QnaPwdCheckAjaxAction.java
@@ -17,7 +17,7 @@ public class QnaPwdCheckAjaxAction extends AjaxAction {
 		// 'qseq' 파라미터가 없는 경우
 		String qseqStr = request.getParameter("qseq");
 		if (qseqStr == null || qseqStr.equals("") || !qseqStr.matches("^[0-9]*$")) {
-			return AjaxResult.requireParameter("qseq");
+			return requireParameter("qseq");
 		}
 
 		int qseq = Integer.parseInt(qseqStr);
@@ -27,7 +27,7 @@ public class QnaPwdCheckAjaxAction extends AjaxAction {
 
 		// 입력된 'qseq'에 해당하는 문의글이 없는 경우
 		if (qnaVO == null) {
-			return AjaxResult.noContent("해당 문의가 존재하지 않습니다");
+			return noContent("해당 문의가 존재하지 않습니다");
 		}
 
 		HttpSession session = request.getSession();
@@ -38,12 +38,12 @@ public class QnaPwdCheckAjaxAction extends AjaxAction {
 
 			// 'qnaVO'가 공개 상태인 경우
 			if (qnaVO.isPublic()) {
-				return AjaxResult.success("공개된 문의입니다", url);
+				return ok("공개된 문의입니다", url);
 			}
 
 			// 사용자가 관리자인 경우
 			if (isAdmin(request)) {
-				return AjaxResult.success("관리자로 확인되었습니다", url);
+				return ok("관리자로 확인되었습니다", url);
 			}
 			break;
 		case "edit":
@@ -51,28 +51,28 @@ public class QnaPwdCheckAjaxAction extends AjaxAction {
 			break;
 		default:
 			// 'mode'가 'view'나 'edit'가 아니면 SC_BAD_REQUEST 를 반환
-			return AjaxResult.badRequest("'mode' 파라미터가 'view'나 'edit'가 아닙니다");
+			return badRequest("'mode' 파라미터가 'view'나 'edit'가 아닙니다");
 		}
 
 		// 세션에 비밀번호 확인 기록이 있는 경우
 		if (session.getAttribute("qnaPass" + qseq) != null) {
-			return AjaxResult.success("비밀번호 확인 기록이 존재합니다", url);
+			return ok("비밀번호 확인 기록이 존재합니다", url);
 		}
 
 		// 'pwd' 파라미터가 없으면 SC_UNAUTHORIZED 를 반환
 		String pwd = request.getParameter("pwd");
 		if (pwd == null || pwd.trim().equals("")) {
-			return AjaxResult.unauthorized("비밀번호를 입력해주세요");
+			return unauthorized("비밀번호를 입력해주세요");
 		}
 
 		// 'pwd'가 비밀번호와 같으면 세션에 비밀번호 확인 기록을 남기고 SC_OK 를 반환
 		if (qnaVO.getPwd().equals(pwd)) {
 			session.setAttribute("qnaPass" + qseq, qseq);
-			return AjaxResult.success("비밀번호가 확인되었습니다", url);
+			return ok("비밀번호가 확인되었습니다", url);
 		}
 
 		// 비밀번호가 틀리면 SC_BAD_REQUEST 를 반환
-		return AjaxResult.badRequest("비밀번호가 일치하지 않습니다");
+		return badRequest("비밀번호가 일치하지 않습니다");
 	}
 
 }

--- a/src/main/java/com/team4/museum/controller/action/qna/QnaReplyAction.java
+++ b/src/main/java/com/team4/museum/controller/action/qna/QnaReplyAction.java
@@ -1,9 +1,10 @@
 package com.team4.museum.controller.action.qna;
 
+import static com.team4.museum.controller.action.member.LoginAjaxAction.isAdmin;
+
 import java.io.IOException;
 
 import com.team4.museum.controller.action.Action;
-import com.team4.museum.controller.action.member.LoginAction;
 import com.team4.museum.dao.QnaDao;
 import com.team4.museum.vo.QnaVO;
 
@@ -20,7 +21,7 @@ public class QnaReplyAction implements Action {
 
 	private boolean updateReply(HttpServletRequest request, HttpServletResponse response) {
 		// 어드민이 아니면 false 를 반환
-		if (!LoginAction.isAdmin(request)) {
+		if (!isAdmin(request)) {
 			return false;
 		}
 

--- a/src/main/java/com/team4/museum/controller/action/qna/QnaViewAction.java
+++ b/src/main/java/com/team4/museum/controller/action/qna/QnaViewAction.java
@@ -1,9 +1,10 @@
 package com.team4.museum.controller.action.qna;
 
+import static com.team4.museum.controller.action.member.LoginAjaxAction.isAdmin;
+
 import java.io.IOException;
 
 import com.team4.museum.controller.action.Action;
-import com.team4.museum.controller.action.member.LoginAction;
 import com.team4.museum.dao.QnaDao;
 import com.team4.museum.vo.QnaVO;
 
@@ -42,7 +43,7 @@ public class QnaViewAction implements Action {
 
 		// 'qseq' 파라미터에 해당하는 'QnaVO'가 있고, 세션에 비밀번호 확인 기록이 있거나 관리자이거나 문의글이 공개 상태인 경우
 		if (qnaVO != null && (session.getAttribute("qnaPass" + qseq) != null
-				|| LoginAction.isAdmin(request)
+				|| isAdmin(request)
 				|| qnaVO.isPublic())) {
 			// qnaVO 를 반환
 			return qnaVO;

--- a/src/main/java/com/team4/museum/util/AjaxResult.java
+++ b/src/main/java/com/team4/museum/util/AjaxResult.java
@@ -1,9 +1,5 @@
 package com.team4.museum.util;
 
-import java.io.IOException;
-
-import jakarta.servlet.http.HttpServletResponse;
-
 public class AjaxResult {
 
 	public static final int OK = 200;
@@ -35,16 +31,6 @@ public class AjaxResult {
 				"\"message\":\"" + message + "\"," +
 				"\"url\":\"" + url + "\"" +
 				"}";
-	}
-
-	public void applyToResponse(HttpServletResponse response) {
-		response.setStatus(code);
-		response.setContentType("application/json");
-		try {
-			response.getWriter().write(toJson());
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
 	}
 
 }

--- a/src/main/java/com/team4/museum/util/AjaxResult.java
+++ b/src/main/java/com/team4/museum/util/AjaxResult.java
@@ -1,18 +1,9 @@
 package com.team4.museum.util;
 
-import static jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
-import static jakarta.servlet.http.HttpServletResponse.SC_FORBIDDEN;
-import static jakarta.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
-import static jakarta.servlet.http.HttpServletResponse.SC_NOT_FOUND;
-import static jakarta.servlet.http.HttpServletResponse.SC_NOT_IMPLEMENTED;
-import static jakarta.servlet.http.HttpServletResponse.SC_NO_CONTENT;
-import static jakarta.servlet.http.HttpServletResponse.SC_OK;
-import static jakarta.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
-
 public class AjaxResult {
 
-	public int code = SC_INTERNAL_SERVER_ERROR;
-	public String message = "알 수 없는 오류가 발생했습니다";
+	public int code;
+	public String message;
 	public String url = "";
 
 	public AjaxResult(int code, String message) {
@@ -30,118 +21,6 @@ public class AjaxResult {
 				"\"message\":\"" + message + "\"," +
 				"\"url\":\"" + url + "\"" +
 				"}";
-	}
-
-	public static AjaxResult success() {
-		return success("성공");
-	}
-
-	public static AjaxResult success(String message) {
-		return success(message, "");
-	}
-
-	public static AjaxResult success(String message, String url) {
-		return new AjaxResult(SC_OK, message, url);
-	}
-
-	public static AjaxResult fail() {
-		return fail("실패");
-	}
-
-	public static AjaxResult fail(String message) {
-		return fail(message, "");
-	}
-
-	public static AjaxResult fail(String message, String url) {
-		return new AjaxResult(SC_INTERNAL_SERVER_ERROR, message, url);
-	}
-
-	public static AjaxResult internalServerError() {
-		return internalServerError("서버 오류가 발생했습니다");
-	}
-
-	public static AjaxResult internalServerError(String message) {
-		return internalServerError(message, "");
-	}
-
-	public static AjaxResult internalServerError(String message, String url) {
-		return new AjaxResult(SC_INTERNAL_SERVER_ERROR, message, url);
-	}
-
-	public static AjaxResult badRequest() {
-		return badRequest("잘못된 요청입니다");
-	}
-
-	public static AjaxResult badRequest(String message) {
-		return badRequest(message, "");
-	}
-
-	public static AjaxResult badRequest(String message, String url) {
-		return new AjaxResult(SC_BAD_REQUEST, message, url);
-	}
-
-	public static AjaxResult unauthorized() {
-		return unauthorized("로그인이 필요합니다");
-	}
-
-	public static AjaxResult unauthorized(String message) {
-		return unauthorized(message, "");
-	}
-
-	public static AjaxResult unauthorized(String message, String url) {
-		return new AjaxResult(SC_UNAUTHORIZED, message, url);
-	}
-
-	public static AjaxResult forbidden() {
-		return forbidden("접근 권한이 없습니다");
-	}
-
-	public static AjaxResult forbidden(String message) {
-		return forbidden(message, "");
-	}
-
-	public static AjaxResult forbidden(String message, String url) {
-		return new AjaxResult(SC_FORBIDDEN, message, url);
-	}
-
-	public static AjaxResult noContent() {
-		return noContent("내용이 없습니다");
-	}
-
-	public static AjaxResult noContent(String message) {
-		return noContent(message, "");
-	}
-
-	public static AjaxResult noContent(String message, String url) {
-		return new AjaxResult(SC_NO_CONTENT, message, url);
-	}
-
-	public static AjaxResult notFound() {
-		return notFound("찾을 수 없습니다");
-	}
-
-	public static AjaxResult notFound(String message) {
-		return notFound(message, "");
-	}
-
-	public static AjaxResult notFound(String message, String url) {
-		return new AjaxResult(SC_NOT_FOUND, message, url);
-	}
-
-	public static AjaxResult notImplemented() {
-		return notImplemented("구현되지 않은 요청입니다");
-	}
-
-	public static AjaxResult notImplemented(String message) {
-		return notImplemented(message, "");
-	}
-
-	public static AjaxResult notImplemented(String message, String url) {
-		return new AjaxResult(SC_NOT_IMPLEMENTED, message, url);
-	}
-
-	public static AjaxResult requireParameter(String parameter) {
-		return badRequest("'" + parameter + "'를 입력해주세요");
 	}
 
 }

--- a/src/main/java/com/team4/museum/util/AjaxResult.java
+++ b/src/main/java/com/team4/museum/util/AjaxResult.java
@@ -1,6 +1,13 @@
 package com.team4.museum.util;
 
+import static jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static jakarta.servlet.http.HttpServletResponse.SC_FORBIDDEN;
 import static jakarta.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
+import static jakarta.servlet.http.HttpServletResponse.SC_NOT_FOUND;
+import static jakarta.servlet.http.HttpServletResponse.SC_NOT_IMPLEMENTED;
+import static jakarta.servlet.http.HttpServletResponse.SC_NO_CONTENT;
+import static jakarta.servlet.http.HttpServletResponse.SC_OK;
+import static jakarta.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
 
 public class AjaxResult {
 
@@ -23,6 +30,118 @@ public class AjaxResult {
 				"\"message\":\"" + message + "\"," +
 				"\"url\":\"" + url + "\"" +
 				"}";
+	}
+
+	public static AjaxResult success() {
+		return success("성공");
+	}
+
+	public static AjaxResult success(String message) {
+		return success(message, "");
+	}
+
+	public static AjaxResult success(String message, String url) {
+		return new AjaxResult(SC_OK, message, url);
+	}
+
+	public static AjaxResult fail() {
+		return fail("실패");
+	}
+
+	public static AjaxResult fail(String message) {
+		return fail(message, "");
+	}
+
+	public static AjaxResult fail(String message, String url) {
+		return new AjaxResult(SC_INTERNAL_SERVER_ERROR, message, url);
+	}
+
+	public static AjaxResult internalServerError() {
+		return internalServerError("서버 오류가 발생했습니다");
+	}
+
+	public static AjaxResult internalServerError(String message) {
+		return internalServerError(message, "");
+	}
+
+	public static AjaxResult internalServerError(String message, String url) {
+		return new AjaxResult(SC_INTERNAL_SERVER_ERROR, message, url);
+	}
+
+	public static AjaxResult badRequest() {
+		return badRequest("잘못된 요청입니다");
+	}
+
+	public static AjaxResult badRequest(String message) {
+		return badRequest(message, "");
+	}
+
+	public static AjaxResult badRequest(String message, String url) {
+		return new AjaxResult(SC_BAD_REQUEST, message, url);
+	}
+
+	public static AjaxResult unauthorized() {
+		return unauthorized("로그인이 필요합니다");
+	}
+
+	public static AjaxResult unauthorized(String message) {
+		return unauthorized(message, "");
+	}
+
+	public static AjaxResult unauthorized(String message, String url) {
+		return new AjaxResult(SC_UNAUTHORIZED, message, url);
+	}
+
+	public static AjaxResult forbidden() {
+		return forbidden("접근 권한이 없습니다");
+	}
+
+	public static AjaxResult forbidden(String message) {
+		return forbidden(message, "");
+	}
+
+	public static AjaxResult forbidden(String message, String url) {
+		return new AjaxResult(SC_FORBIDDEN, message, url);
+	}
+
+	public static AjaxResult noContent() {
+		return noContent("내용이 없습니다");
+	}
+
+	public static AjaxResult noContent(String message) {
+		return noContent(message, "");
+	}
+
+	public static AjaxResult noContent(String message, String url) {
+		return new AjaxResult(SC_NO_CONTENT, message, url);
+	}
+
+	public static AjaxResult notFound() {
+		return notFound("찾을 수 없습니다");
+	}
+
+	public static AjaxResult notFound(String message) {
+		return notFound(message, "");
+	}
+
+	public static AjaxResult notFound(String message, String url) {
+		return new AjaxResult(SC_NOT_FOUND, message, url);
+	}
+
+	public static AjaxResult notImplemented() {
+		return notImplemented("구현되지 않은 요청입니다");
+	}
+
+	public static AjaxResult notImplemented(String message) {
+		return notImplemented(message, "");
+	}
+
+	public static AjaxResult notImplemented(String message, String url) {
+		return new AjaxResult(SC_NOT_IMPLEMENTED, message, url);
+	}
+
+	public static AjaxResult requireParameter(String parameter) {
+		return badRequest("'" + parameter + "'를 입력해주세요");
 	}
 
 }

--- a/src/main/java/com/team4/museum/util/AjaxResult.java
+++ b/src/main/java/com/team4/museum/util/AjaxResult.java
@@ -1,19 +1,11 @@
 package com.team4.museum.util;
 
+import static jakarta.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
+
 public class AjaxResult {
 
-	public static final int OK = 200;
-	public static final int CREATED = 201;
-	public static final int ACCEPTED = 202;
-	public static final int NO_CONTENT = 204;
-	public static final int BAD_REQUEST = 400;
-	public static final int UNAUTHORIZED = 401;
-	public static final int FORBIDDEN = 403;
-	public static final int NOT_FOUND = 404;
-	public static final int INTERNAL_SERVER_ERROR = 500;
-
-	public int code = INTERNAL_SERVER_ERROR;
-	public String message = "";
+	public int code = SC_INTERNAL_SERVER_ERROR;
+	public String message = "알 수 없는 오류가 발생했습니다";
 	public String url = "";
 
 	public AjaxResult(int code, String message) {

--- a/src/main/webapp/script/ajax.js
+++ b/src/main/webapp/script/ajax.js
@@ -1,7 +1,14 @@
+var lastAjaxRequest = null;
+
 /**
  * AJAX 요청을 전송하는 함수
  */
 function ajax(requestUrl, requestBody, ajaxHandler) {
+	// 마지막 요청 취소
+	if (lastAjaxRequest) {
+		lastAjaxRequest.abort();
+	}
+
 	// ajax(requestBody, ajaxHandler) 형식의 호출을 지원
 	if (typeof requestUrl === 'object') {
 		ajaxHandler = requestBody;
@@ -43,6 +50,11 @@ function ajax(requestUrl, requestBody, ajaxHandler) {
 		if (xhr.readyState !== 4) {
 			return;
 		}
+		
+		// abort()로 취소된 요청은 무시
+		if(xhr.status === 0){
+			return;
+		}
 
 		// 응답 완료 시 ajaxHandler() 실행
 		ajaxHandler(xhr.status, JSON.parse(xhr.responseText));
@@ -50,6 +62,7 @@ function ajax(requestUrl, requestBody, ajaxHandler) {
 
 	// requestBody로 POST 요청 전송
 	xhr.send(requestBody);
+	lastAjaxRequest = xhr;
 }
 
 function ajaxForm(form, callback) {

--- a/src/main/webapp/script/ajax.js
+++ b/src/main/webapp/script/ajax.js
@@ -96,6 +96,14 @@ var defaultAjaxHandler = function(status, response) {
 	var message = response.message;
 	switch (status) {
 		case 200: // OK
+			// 200 상태 코드는 url 값이 존재하면 메시지를 생략
+			if (url) {
+				location.href = url;
+			} else if (message) {
+				alert(message);
+			}
+			return;
+
 		case 201: // Created
 		case 202: // Accepted
 			break;
@@ -125,10 +133,10 @@ var defaultAjaxHandler = function(status, response) {
 			message = message || "알 수 없는 오류가 발생했습니다.";
 			break;
 	}
-
+	if (message) {
+		alert(message);
+	}
 	if (url) {
 		location.href = url;
-	} else if (message) {
-		alert(message);
 	}
 };


### PR DESCRIPTION
## [`ajax.js`: 새로운 요청이 호출되면 마지막 AJAX 요청을 취소](https://github.com/himedia-mini-4/museum/commit/648a542502ec35bff4f09585957f857e6b0c8dd6)
사용자가 요청 버튼을 여러번 누르면 요청이 여러번 진행되는 문제를 해결하기 위해 마지막 AJAX 요청을 취소하도록 수정했습니다.

-----

## [`AjaxAction.java`: AJAX를 처리하는 액션을 위한 AjaxAction 추상 클래스 추가](https://github.com/himedia-mini-4/museum/commit/27213ce7d74e9f7cb247dfba0215b9cc410ab31b)
AJAX 처리를 담당하는 클래스의 이름을 `**AjaxAction`으로 통합하고, 이 클래스들의 부모 클래스인 `AjaxAction`을 추가했습니다.

````java
abstract public class AjaxAction implements Action {

	abstract protected AjaxResult handleAjaxRequest(
		HttpServletRequest request, 
		HttpServletResponse response
	) throws ServletException, IOException;

}
````

`AjaxResult`를 반환하는 `handleAjaxRequest` 메서드를 작성하면 해당 메서드를 통해 AJAX 요청에 응답합니다.

> #### 적용 예시
> ````java
> public class LogoutAjaxAction extends AjaxAction {
> 
> 	protected AjaxResult handleAjaxRequest(HttpServletRequest request, HttpServletResponse response) {
> 		request.getSession().removeAttribute("loginUser");
> 
> 		// 돌아갈 페이지 정보를 확인하고, 없으면 index 페이지로 이동
> 		String returnUrl = "museum.do?command=index";
> 		String returnUrlParam = (String) request.getParameter("returnUrl");
> 		if (returnUrlParam != null && !returnUrlParam.isEmpty()) {
> 			returnUrl = UrlUtil.decode(returnUrlParam);
> 		}
> 
> 		// 돌아갈 페이지 정보와 함께 OK 를 반환
> 		return new AjaxResult(OK, "로그아웃 되었습니다", returnUrl);
> 	}
> 
> }
> ````

-----

### 추가로 `OK`, `BAD_REQUEST`, `UNAUTHORIZED` 등 자주 사용되는 상태 코드로 AjaxResult 갹체를 생성하는 팩토리 메소드를 추가했습니다.

이제 결과를 반환하기 위해 상태 코드를 탐색하고, 객체를 생성하는 복잡한 과정을 생략할 수 있습니다.

> #### 적용 예시
> ````java
> // 'id' 파라미터가 없는 경우
> String id = request.getParameter("id");
> if (id == null || id.equals("")) return requireParameter("id");
> 
> // 'pwd' 파라미터가 없는 경우
> String pwd = request.getParameter("pwd");
> if (pwd == null || pwd.equals("")) return requireParameter("pwd");
> 
> // 입력된 'id'에 해당하는 사용자 계정이 없는 경우
> MemberVO mvo = MemberDao.getInstance().getMember(id);
> if (mvo == null) return notFound("존재하지 않는 아이디입니다");
> 
> // 입력된 'pwd'가 사용자 계정의 비밀번호와 일치하지 않는 경우
> if (!mvo.getPwd().equals(pwd)) return badRequest("비밀번호가 일치하지 않습니다");
> 
> // 돌아갈 페이지 정보와 함께 성공 메시지를 반환
> return ok("로그인에 성공하였습니다", "museum.do?command=index");
> ````