### PR TITLE
feat: AJAX 유틸 기능 추가

### DIFF
--- a/src/main/java/com/team4/museum/controller/action/AjaxAction.java
+++ b/src/main/java/com/team4/museum/controller/action/AjaxAction.java
@@ -12,7 +12,7 @@ import static jakarta.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
 
 import java.io.IOException;
 
-import com.team4.museum.util.AjaxResult;
+import com.team4.museum.util.ajax.AjaxResult;
 
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;

--- a/src/main/java/com/team4/museum/controller/action/AjaxAction.java
+++ b/src/main/java/com/team4/museum/controller/action/AjaxAction.java
@@ -178,4 +178,40 @@ abstract public class AjaxAction implements Action {
 
 		return returnUrl;
 	}
+
+	/**
+	 * 요구되는 파라미터를 문자열로 반환합니다. 없을 경우 AjaxException을 발생합니다.
+	 * 
+	 * @param request
+	 * @param parameter
+	 * @return
+	 * @throws AjaxException
+	 */
+	protected String mustGetString(String parameter) throws AjaxException {
+		if (currentRequest == null) {
+			throw new AjaxException(SC_INTERNAL_SERVER_ERROR, "메소드는 반드시 handleAjaxRequest 메소드 내에서만 사용해주세요");
+		}
+
+		String str = currentRequest.getParameter(parameter);
+		if (str == null || str.equals("")) {
+			throw new AjaxException(SC_BAD_REQUEST, "'" + parameter + "'를 입력해주세요");
+		}
+		return str;
+	}
+
+	/**
+	 * 요구되는 파라미터를 정수로 반환합니다. 없거나 정수가 아닐 경우 AjaxException을 발생합니다.
+	 * 
+	 * @param request
+	 * @param parameter
+	 * @return 정수
+	 * @throws AjaxException
+	 */
+	protected int mustGetInt(String parameter) throws AjaxException {
+		try {
+			return Integer.parseInt(mustGetString(parameter));
+		} catch (NumberFormatException e) {
+			throw new AjaxException(SC_BAD_REQUEST, "'" + parameter + "'는 숫자로 입력해주세요");
+		}
+	}
 }

--- a/src/main/java/com/team4/museum/controller/action/AjaxAction.java
+++ b/src/main/java/com/team4/museum/controller/action/AjaxAction.java
@@ -12,6 +12,8 @@ import static jakarta.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
 
 import java.io.IOException;
 
+import com.team4.museum.util.UrlUtil;
+import com.team4.museum.util.ajax.AjaxException;
 import com.team4.museum.util.ajax.AjaxResult;
 
 import jakarta.servlet.ServletException;
@@ -28,6 +30,8 @@ abstract public class AjaxAction implements Action {
 		try {
 			currentRequest = request;
 			result = handleAjaxRequest(request, response);
+		} catch (AjaxException e) {
+			result = badRequest(e.getMessage());
 		} catch (Exception e) {
 			e.printStackTrace();
 			result = internalServerError();
@@ -41,7 +45,7 @@ abstract public class AjaxAction implements Action {
 	}
 
 	abstract protected AjaxResult handleAjaxRequest(HttpServletRequest request, HttpServletResponse response)
-			throws ServletException, IOException;
+			throws ServletException, IOException, AjaxException;
 
 	protected static AjaxResult ok() {
 		return ok("성공");
@@ -153,5 +157,25 @@ abstract public class AjaxAction implements Action {
 
 	protected static AjaxResult requireParameter(String parameter) {
 		return badRequest("'" + parameter + "'를 입력해주세요");
+	}
+
+	/**
+	 * 돌아갈 페이지 URL을 반환합니다. 없을 경우 기본값으로 index 페이지로 이동합니다.
+	 * 
+	 * @return
+	 * @throws AjaxException
+	 */
+	protected String getReturnUrl() throws AjaxException {
+		if (currentRequest == null) {
+			throw new AjaxException(SC_INTERNAL_SERVER_ERROR, "메소드는 반드시 handleAjaxRequest 메소드 내에서만 사용해주세요");
+		}
+
+		String returnUrl = "museum.do?command=index";
+		String returnUrlParam = (String) currentRequest.getParameter("returnUrl");
+		if (returnUrlParam != null && !returnUrlParam.isEmpty()) {
+			returnUrl = UrlUtil.decode(returnUrlParam);
+		}
+
+		return returnUrl;
 	}
 }

--- a/src/main/java/com/team4/museum/controller/action/AjaxAction.java
+++ b/src/main/java/com/team4/museum/controller/action/AjaxAction.java
@@ -20,17 +20,24 @@ import jakarta.servlet.http.HttpServletResponse;
 
 abstract public class AjaxAction implements Action {
 
+	private HttpServletRequest currentRequest;
+
 	@Override
 	public void execute(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-		AjaxResult result = handleAjaxRequest(request, response);
+		AjaxResult result;
+		try {
+			currentRequest = request;
+			result = handleAjaxRequest(request, response);
+		} catch (Exception e) {
+			e.printStackTrace();
+			result = internalServerError();
+		} finally {
+			currentRequest = null;
+		}
 
 		response.setStatus(result.code);
 		response.setContentType("application/json");
-		try {
-			response.getWriter().write(result.toJson());
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
+		response.getWriter().write(result.toJson());
 	}
 
 	abstract protected AjaxResult handleAjaxRequest(HttpServletRequest request, HttpServletResponse response)

--- a/src/main/java/com/team4/museum/controller/action/member/JoinAjaxAction.java
+++ b/src/main/java/com/team4/museum/controller/action/member/JoinAjaxAction.java
@@ -13,42 +13,14 @@ public class JoinAjaxAction extends AjaxAction {
 
 	protected AjaxResult handleAjaxRequest(HttpServletRequest request, HttpServletResponse response)
 			throws AjaxException {
+		// 회원가입에 필요한 정보를 받아옴 (name, id, pwd, email, phone)
+		// mustGetString() 호출 시 요청한 파라미터가 없으면 AjaxException을 던짐
 		MemberVO mvo = new MemberVO();
-
-		// 'name' 파라미터가 없는 경우
-		String name = request.getParameter("name");
-		if (name == null || name.equals("")) {
-			return requireParameter("name");
-		}
-		mvo.setName(name);
-
-		// 'id' 파라미터가 없는 경우
-		String id = request.getParameter("id");
-		if (id == null || id.equals("")) {
-			return requireParameter("id");
-		}
-		mvo.setId(id);
-
-		// 'pwd' 파라미터가 없는 경우
-		String pwd = request.getParameter("pwd");
-		if (pwd == null || pwd.equals("")) {
-			return requireParameter("pwd");
-		}
-		mvo.setPwd(pwd);
-
-		// 'email' 파라미터가 없는 경우
-		String email = request.getParameter("email");
-		if (email == null || email.equals("")) {
-			return requireParameter("email");
-		}
-		mvo.setEmail(email);
-
-		// 'phone' 파라미터가 없는 경우
-		String phone = request.getParameter("phone");
-		if (phone == null || phone.equals("")) {
-			return requireParameter("phone");
-		}
-		mvo.setPhone(phone);
+		mvo.setName(mustGetString("name"));
+		mvo.setId(mustGetString("id"));
+		mvo.setPwd(mustGetString("pwd"));
+		mvo.setEmail(mustGetString("email"));
+		mvo.setPhone(mustGetString("phone"));
 
 		// 회원가입에 실패한 경우
 		if (MemberDao.getInstance().insertMember(mvo) == 0) {

--- a/src/main/java/com/team4/museum/controller/action/member/JoinAjaxAction.java
+++ b/src/main/java/com/team4/museum/controller/action/member/JoinAjaxAction.java
@@ -2,7 +2,7 @@ package com.team4.museum.controller.action.member;
 
 import com.team4.museum.controller.action.AjaxAction;
 import com.team4.museum.dao.MemberDao;
-import com.team4.museum.util.UrlUtil;
+import com.team4.museum.util.ajax.AjaxException;
 import com.team4.museum.util.ajax.AjaxResult;
 import com.team4.museum.vo.MemberVO;
 
@@ -11,7 +11,8 @@ import jakarta.servlet.http.HttpServletResponse;
 
 public class JoinAjaxAction extends AjaxAction {
 
-	protected AjaxResult handleAjaxRequest(HttpServletRequest request, HttpServletResponse response) {
+	protected AjaxResult handleAjaxRequest(HttpServletRequest request, HttpServletResponse response)
+			throws AjaxException {
 		MemberVO mvo = new MemberVO();
 
 		// 'name' 파라미터가 없는 경우
@@ -54,15 +55,8 @@ public class JoinAjaxAction extends AjaxAction {
 			return internalServerError("회원가입에 실패하였습니다");
 		}
 
-		// 돌아갈 페이지 정보를 확인하고, 없으면 index 페이지로 이동
-		String returnUrl = "museum.do?command=index";
-		String returnUrlParam = (String) request.getParameter("returnUrl");
-		if (returnUrlParam != null && !returnUrlParam.isEmpty()) {
-			returnUrl = UrlUtil.decode(returnUrlParam);
-		}
-
 		// 돌아갈 페이지 정보와 함께 성공 메시지를 반환
-		return ok("회원가입이 완료되었습니다", returnUrl);
+		return ok("회원가입이 완료되었습니다", getReturnUrl());
 	}
 
 }

--- a/src/main/java/com/team4/museum/controller/action/member/JoinAjaxAction.java
+++ b/src/main/java/com/team4/museum/controller/action/member/JoinAjaxAction.java
@@ -2,8 +2,8 @@ package com.team4.museum.controller.action.member;
 
 import com.team4.museum.controller.action.AjaxAction;
 import com.team4.museum.dao.MemberDao;
-import com.team4.museum.util.AjaxResult;
 import com.team4.museum.util.UrlUtil;
+import com.team4.museum.util.ajax.AjaxResult;
 import com.team4.museum.vo.MemberVO;
 
 import jakarta.servlet.http.HttpServletRequest;

--- a/src/main/java/com/team4/museum/controller/action/member/LoginAjaxAction.java
+++ b/src/main/java/com/team4/museum/controller/action/member/LoginAjaxAction.java
@@ -17,17 +17,10 @@ public class LoginAjaxAction extends AjaxAction {
 
 	protected AjaxResult handleAjaxRequest(HttpServletRequest request, HttpServletResponse response)
 			throws AjaxException {
-		// 'id' 파라미터가 없는 경우
-		String id = request.getParameter("id");
-		if (id == null || id.equals("")) {
-			return requireParameter("id");
-		}
-
-		// 'pwd' 파라미터가 없는 경우
-		String pwd = request.getParameter("pwd");
-		if (pwd == null || pwd.equals("")) {
-			return requireParameter("pwd");
-		}
+		// 로그인에 필요한 정보를 받아옴 (id, pwd)
+		// mustGetString() 호출 시 요청한 파라미터가 없으면 AjaxException을 던짐
+		String id = mustGetString("id");
+		String pwd = mustGetString("pwd");
 
 		// 입력된 'id'에 해당하는 사용자 계정이 없는 경우
 		MemberVO mvo = MemberDao.getInstance().getMember(id);

--- a/src/main/java/com/team4/museum/controller/action/member/LoginAjaxAction.java
+++ b/src/main/java/com/team4/museum/controller/action/member/LoginAjaxAction.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import com.team4.museum.controller.action.AjaxAction;
 import com.team4.museum.dao.MemberDao;
 import com.team4.museum.util.UrlUtil;
+import com.team4.museum.util.ajax.AjaxException;
 import com.team4.museum.util.ajax.AjaxResult;
 import com.team4.museum.vo.MemberVO;
 
@@ -14,7 +15,8 @@ import jakarta.servlet.http.HttpSession;
 
 public class LoginAjaxAction extends AjaxAction {
 
-	protected AjaxResult handleAjaxRequest(HttpServletRequest request, HttpServletResponse response) {
+	protected AjaxResult handleAjaxRequest(HttpServletRequest request, HttpServletResponse response)
+			throws AjaxException {
 		// 'id' 파라미터가 없는 경우
 		String id = request.getParameter("id");
 		if (id == null || id.equals("")) {
@@ -42,15 +44,8 @@ public class LoginAjaxAction extends AjaxAction {
 		HttpSession session = request.getSession();
 		session.setAttribute("loginUser", mvo);
 
-		// 돌아갈 페이지 정보를 확인하고, 없으면 index 페이지로 이동
-		String returnUrl = "museum.do?command=index";
-		String returnUrlParam = (String) request.getParameter("returnUrl");
-		if (returnUrlParam != null && !returnUrlParam.isEmpty()) {
-			returnUrl = UrlUtil.decode(returnUrlParam);
-		}
-
 		// 돌아갈 페이지 정보와 함께 성공 메시지를 반환
-		return ok("로그인에 성공하였습니다", returnUrl);
+		return ok("로그인에 성공하였습니다", getReturnUrl());
 	}
 
 	/**

--- a/src/main/java/com/team4/museum/controller/action/member/LoginAjaxAction.java
+++ b/src/main/java/com/team4/museum/controller/action/member/LoginAjaxAction.java
@@ -4,8 +4,8 @@ import java.io.IOException;
 
 import com.team4.museum.controller.action.AjaxAction;
 import com.team4.museum.dao.MemberDao;
-import com.team4.museum.util.AjaxResult;
 import com.team4.museum.util.UrlUtil;
+import com.team4.museum.util.ajax.AjaxResult;
 import com.team4.museum.vo.MemberVO;
 
 import jakarta.servlet.http.HttpServletRequest;

--- a/src/main/java/com/team4/museum/controller/action/member/LogoutAjaxAction.java
+++ b/src/main/java/com/team4/museum/controller/action/member/LogoutAjaxAction.java
@@ -11,6 +11,7 @@ public class LogoutAjaxAction extends AjaxAction {
 
 	protected AjaxResult handleAjaxRequest(HttpServletRequest request, HttpServletResponse response)
 			throws AjaxException {
+		// 로그인한 사용자 정보를 세션에서 제거
 		request.getSession().removeAttribute("loginUser");
 
 		// 돌아갈 페이지 정보와 함께 성공 메시지를 반환

--- a/src/main/java/com/team4/museum/controller/action/member/LogoutAjaxAction.java
+++ b/src/main/java/com/team4/museum/controller/action/member/LogoutAjaxAction.java
@@ -1,8 +1,8 @@
 package com.team4.museum.controller.action.member;
 
 import com.team4.museum.controller.action.AjaxAction;
-import com.team4.museum.util.AjaxResult;
 import com.team4.museum.util.UrlUtil;
+import com.team4.museum.util.ajax.AjaxResult;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;

--- a/src/main/java/com/team4/museum/controller/action/member/LogoutAjaxAction.java
+++ b/src/main/java/com/team4/museum/controller/action/member/LogoutAjaxAction.java
@@ -1,7 +1,7 @@
 package com.team4.museum.controller.action.member;
 
 import com.team4.museum.controller.action.AjaxAction;
-import com.team4.museum.util.UrlUtil;
+import com.team4.museum.util.ajax.AjaxException;
 import com.team4.museum.util.ajax.AjaxResult;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -9,18 +9,12 @@ import jakarta.servlet.http.HttpServletResponse;
 
 public class LogoutAjaxAction extends AjaxAction {
 
-	protected AjaxResult handleAjaxRequest(HttpServletRequest request, HttpServletResponse response) {
+	protected AjaxResult handleAjaxRequest(HttpServletRequest request, HttpServletResponse response)
+			throws AjaxException {
 		request.getSession().removeAttribute("loginUser");
 
-		// 돌아갈 페이지 정보를 확인하고, 없으면 index 페이지로 이동
-		String returnUrl = "museum.do?command=index";
-		String returnUrlParam = (String) request.getParameter("returnUrl");
-		if (returnUrlParam != null && !returnUrlParam.isEmpty()) {
-			returnUrl = UrlUtil.decode(returnUrlParam);
-		}
-
 		// 돌아갈 페이지 정보와 함께 성공 메시지를 반환
-		return ok("로그아웃 되었습니다", returnUrl);
+		return ok("로그아웃 되었습니다", getReturnUrl());
 	}
 
 }

--- a/src/main/java/com/team4/museum/controller/action/member/MyPageFavoriteAjaxAction.java
+++ b/src/main/java/com/team4/museum/controller/action/member/MyPageFavoriteAjaxAction.java
@@ -7,7 +7,7 @@ import java.io.IOException;
 
 import com.team4.museum.controller.action.AjaxAction;
 import com.team4.museum.dao.FavoriteDao;
-import com.team4.museum.util.AjaxResult;
+import com.team4.museum.util.ajax.AjaxResult;
 import com.team4.museum.vo.MemberVO;
 
 import jakarta.servlet.http.HttpServletRequest;

--- a/src/main/java/com/team4/museum/controller/action/qna/QnaPwdCheckAjaxAction.java
+++ b/src/main/java/com/team4/museum/controller/action/qna/QnaPwdCheckAjaxAction.java
@@ -5,7 +5,7 @@ import java.util.Map;
 
 import com.team4.museum.controller.action.AjaxAction;
 import com.team4.museum.dao.QnaDao;
-import com.team4.museum.util.AjaxResult;
+import com.team4.museum.util.ajax.AjaxResult;
 import com.team4.museum.vo.QnaVO;
 
 import jakarta.annotation.Nonnull;

--- a/src/main/java/com/team4/museum/controller/action/qna/QnaPwdCheckAjaxAction.java
+++ b/src/main/java/com/team4/museum/controller/action/qna/QnaPwdCheckAjaxAction.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 import com.team4.museum.controller.action.AjaxAction;
 import com.team4.museum.dao.QnaDao;
+import com.team4.museum.util.ajax.AjaxException;
 import com.team4.museum.util.ajax.AjaxResult;
 import com.team4.museum.vo.QnaVO;
 
@@ -38,24 +39,23 @@ public class QnaPwdCheckAjaxAction extends AjaxAction {
 				}));
 	}
 
-	protected AjaxResult handleAjaxRequest(HttpServletRequest request, HttpServletResponse response) {
-		String mode = request.getParameter("mode");
-		if (mode == null || subActions.get(mode) == null) {
-			return requireParameter("mode");
-		}
+	protected AjaxResult handleAjaxRequest(HttpServletRequest request, HttpServletResponse response)
+			throws AjaxException {
+		// 로그인에 필요한 정보를 받아옴 (mode, qseq)
+		// mustGetString() 호출 시 요청한 파라미터가 없으면 AjaxException을 던짐
+		String mode = mustGetString("mode");
+		int qseq = mustGetInt("qseq");
+
+		// 'mode'에 해당하는 서브 액션이 없는 경우
 		SubAjaxAction subAction = subActions.get(mode);
-
-		// 'qseq' 파라미터가 없는 경우
-		String qseqStr = request.getParameter("qseq");
-		if (qseqStr == null || qseqStr.equals("") || !qseqStr.matches("^[0-9]*$")) {
-			return requireParameter("qseq");
+		if (subAction == null) {
+			return badRequest("잘못된 요청입니다");
 		}
-
-		int qseq = Integer.parseInt(qseqStr);
-		QnaDao qdao = QnaDao.getInstance();
-		QnaVO qnaVO = qdao.getQna(qseq);
 
 		// 입력된 'qseq'에 해당하는 문의글이 없는 경우
+
+		QnaDao qdao = QnaDao.getInstance();
+		QnaVO qnaVO = qdao.getQna(qseq);
 		if (qnaVO == null) {
 			return noContent("해당 문의가 존재하지 않습니다");
 		}

--- a/src/main/java/com/team4/museum/controller/action/qna/QnaReplyAjaxAction.java
+++ b/src/main/java/com/team4/museum/controller/action/qna/QnaReplyAjaxAction.java
@@ -4,6 +4,7 @@ import static com.team4.museum.controller.action.member.LoginAjaxAction.isAdmin;
 
 import com.team4.museum.controller.action.AjaxAction;
 import com.team4.museum.dao.QnaDao;
+import com.team4.museum.util.ajax.AjaxException;
 import com.team4.museum.util.ajax.AjaxResult;
 import com.team4.museum.vo.QnaVO;
 
@@ -12,27 +13,23 @@ import jakarta.servlet.http.HttpServletResponse;
 
 public class QnaReplyAjaxAction extends AjaxAction {
 
-	protected AjaxResult handleAjaxRequest(HttpServletRequest request, HttpServletResponse response) {
+	protected AjaxResult handleAjaxRequest(HttpServletRequest request, HttpServletResponse response)
+			throws AjaxException {
+		// 로그인에 필요한 정보를 받아옴 (qseq)
+		// mustGetInt() 호출 시 요청한 파라미터가 없거나 정수로 변환할 수 없으면 AjaxException을 던짐
+		int qseq = mustGetInt("qseq");
+
 		// 사용자가 관리자가 아닌 경우
 		if (!isAdmin(request)) {
 			return forbidden("접근 권한이 없습니다");
 		}
 
-		// 'qseq' 파라미터가 없는 경우
-		String qseqParam = request.getParameter("qseq");
-		if (qseqParam == null || qseqParam.equals("") || !qseqParam.matches("^[0-9]*$")) {
-			return requireParameter("qseq");
-		}
-
-		int qseq = Integer.parseInt(qseqParam);
-		QnaDao qdao = QnaDao.getInstance();
-
 		// 입력된 'qseq'에 해당하는 문의글이 없는 경우
+		QnaDao qdao = QnaDao.getInstance();
 		QnaVO qnaVO = qdao.getQna(qseq);
 		if (qnaVO == null) {
 			return noContent("해당 문의가 존재하지 않습니다");
 		}
-		request.setAttribute("qnaVO", qnaVO);
 
 		try {
 			// 답변을 업데이트

--- a/src/main/java/com/team4/museum/controller/action/qna/QnaReplyAjaxAction.java
+++ b/src/main/java/com/team4/museum/controller/action/qna/QnaReplyAjaxAction.java
@@ -4,7 +4,7 @@ import static com.team4.museum.controller.action.member.LoginAjaxAction.isAdmin;
 
 import com.team4.museum.controller.action.AjaxAction;
 import com.team4.museum.dao.QnaDao;
-import com.team4.museum.util.AjaxResult;
+import com.team4.museum.util.ajax.AjaxResult;
 import com.team4.museum.vo.QnaVO;
 
 import jakarta.servlet.http.HttpServletRequest;

--- a/src/main/java/com/team4/museum/controller/action/qna/QnaWriteAjaxAction.java
+++ b/src/main/java/com/team4/museum/controller/action/qna/QnaWriteAjaxAction.java
@@ -6,7 +6,7 @@ import static com.team4.museum.controller.action.qna.QnaPwdCheckAjaxAction.saveP
 
 import com.team4.museum.controller.action.AjaxAction;
 import com.team4.museum.dao.QnaDao;
-import com.team4.museum.util.AjaxResult;
+import com.team4.museum.util.ajax.AjaxResult;
 import com.team4.museum.vo.QnaVO;
 
 import jakarta.servlet.http.HttpServletRequest;

--- a/src/main/java/com/team4/museum/util/ajax/AjaxException.java
+++ b/src/main/java/com/team4/museum/util/ajax/AjaxException.java
@@ -1,0 +1,17 @@
+package com.team4.museum.util.ajax;
+
+final public class AjaxException extends Exception {
+
+	private static final long serialVersionUID = 4010270985151127478L;
+
+	private int statusCode;
+
+	public AjaxException(int statusCode, String message) {
+		super(message);
+		this.statusCode = statusCode;
+	}
+
+	public int getStatusCode() {
+		return statusCode;
+	}
+}

--- a/src/main/java/com/team4/museum/util/ajax/AjaxResult.java
+++ b/src/main/java/com/team4/museum/util/ajax/AjaxResult.java
@@ -1,4 +1,4 @@
-package com.team4.museum.util;
+package com.team4.museum.util.ajax;
 
 public class AjaxResult {
 


### PR DESCRIPTION
## [돌아갈 페이지 URL를 반환하는 `getReturnUrl()` 메서드 추가](https://github.com/himedia-mini-4/museum/commit/1f44f414d308eecd5714f10f5ccd5e21c308f898)
로그인 혹은 로그아웃 등에 사용되는 `returnUrl` 파라미터를 파싱하고 반환하는 유틸 메소드 추가했습니다.

-----

## [파라미터를 무조건 반환하는 `mustGetString()`, `mustGetInt()` 메서드 추가](https://github.com/himedia-mini-4/museum/commit/30224e5fc5b9f9f5f76a3fdbf3bcf4b4eb41a56d) 

파라미터가 없거나 빈 문자열이면 실패를 반환하는 코드의 반복을 개선하기 위해 `mustGet~` 메서드를 추가했습니다.
파라미터를 가져올 수 없거나, 요청한 자료형에 일치하지 않는 경우 자동으로 `BAD_REQUEST` 상태 코드를 반환합니다.

 ### 기존 코드
````java
// 'name' 파라미터가 없는 경우
String name = request.getParameter("name");
if (name == null || name.equals("")) {
	return requireParameter("name");
}
mvo.setName(name);

// 'id' 파라미터가 없는 경우
String id = request.getParameter("id");
if (id == null || id.equals("")) {
	return requireParameter("id");
}
mvo.setId(id);

// 'pwd' 파라미터가 없는 경우
String pwd = request.getParameter("pwd");
if (pwd == null || pwd.equals("")) {
	return requireParameter("pwd");
}
mvo.setPwd(pwd);

// 'email' 파라미터가 없는 경우
String email = request.getParameter("email");
if (email == null || email.equals("")) {
	return requireParameter("email");
}
mvo.setEmail(email);

// 'phone' 파라미터가 없는 경우
String phone = request.getParameter("phone");
if (phone == null || phone.equals("")) {
	return requireParameter("phone");
}
mvo.setPhone(phone);
````

### `mustGet~` 메서드를 사용한 개선 코드
````java
mvo.setName(mustGetString("name"));
mvo.setId(mustGetString("id"));
mvo.setPwd(mustGetString("pwd"));
mvo.setEmail(mustGetString("email"));
mvo.setPhone(mustGetString("phone"));
````